### PR TITLE
docs: fix typos in bq27441 and vl53l1x README files.

### DIFF
--- a/lib/bq27441/README.md
+++ b/lib/bq27441/README.md
@@ -1,6 +1,6 @@
 # MicroPython BQ27441 Library
 
-This library is a port of the [SparkFun BQ27441-G1A LiPo Fuel Gauge Arduino Libraryry](https://github.com/sparkfun/SparkFun_BQ27441_Arduino_Library).
+This library is a port of the [SparkFun BQ27441-G1A LiPo Fuel Gauge Arduino Library](https://github.com/sparkfun/SparkFun_BQ27441_Arduino_Library).
 
 The examples could be easily tested with [mpremote](https://docs.micropython.org/en/latest/reference/mpremote.html) with the following command :
 

--- a/lib/vl53l1x/README.md
+++ b/lib/vl53l1x/README.md
@@ -1,6 +1,6 @@
 # MicroPython Driver for the vl53l1x ToF sensor
 
-This library is a port of the [Micromicropython driver for the vl53l1x ToF sensor](https://github.com/drakxtwo/vl53l1x_pico).
+This library is a port of the [MicroPython driver for the vl53l1x ToF sensor](https://github.com/drakxtwo/vl53l1x_pico).
 
 The examples could be easily tested with [mpremote](https://docs.micropython.org/en/latest/reference/mpremote.html) with the following command :
 


### PR DESCRIPTION
Closes #17
Closes #18

## Summary
- bq27441/README.md: fix `"Libraryry"` → `"Library"`
- vl53l1x/README.md: fix `"Micromicropython"` → `"MicroPython"`

## Test plan
- [x] Verify corrected text in both README files