### PR TITLE
mcp23009e: fix package name typo in manifest.

### DIFF
--- a/lib/mcp23009e/manifest.py
+++ b/lib/mcp23009e/manifest.py
@@ -3,4 +3,4 @@ metadata(
     version="0.0.1",
 )
 
-package("mcp23999e")
+package("mcp23009e")


### PR DESCRIPTION
## Summary
- Fix typo in `lib/mcp23009e/manifest.py`: `mcp23999e` → `mcp23009e`
- Without this fix, the package is not installable under the correct name via `mip` or `mpremote`

Closes #13