### PR TITLE
hts221: add missing self parameter in getAv method.

### DIFF
--- a/lib/hts221/hts221/device.py
+++ b/lib/hts221/hts221/device.py
@@ -78,7 +78,7 @@ class HTS221(object):
         self.setReg(t | odr, HTS221_CTRL_REG1)
 
     # get/set Humidity and temperature average configuration
-    def getAv():
+    def getAv(self):
         return self.getReg(HTS221_AV_CONF)
 
     def setAv(self, av=0):


### PR DESCRIPTION
## Summary
- Add missing `self` parameter to `getAv()` method in `lib/hts221/hts221/device.py`
- Without this fix, calling `getAv()` raises a `TypeError`

Closes #12