### PR TITLE
wsen-hids: Add test scenario for humidity sensor driver

### DIFF
--- a/tests/runner/executor.py
+++ b/tests/runner/executor.py
@@ -35,22 +35,29 @@ def load_driver_mock(driver_name, fake_i2c, module_name=None):
     # Patch time module to add MicroPython-specific functions
     import time
 
+    # Use a monotonic clock to emulate MicroPython's ticks_* semantics
+    monotonic = getattr(time, "monotonic", time.perf_counter)
+
     if not hasattr(time, "sleep_ms"):
         time.sleep_ms = lambda ms: time.sleep(ms / 1000)
     if not hasattr(time, "sleep_us"):
         time.sleep_us = lambda us: time.sleep(us / 1000000)
+    if not hasattr(time, "ticks_ms"):
+        time.ticks_ms = lambda: int(monotonic() * 1000)
+    if not hasattr(time, "ticks_us"):
+        time.ticks_us = lambda: int(monotonic() * 1000000)
+    if not hasattr(time, "ticks_diff"):
+        time.ticks_diff = lambda a, b: a - b
 
     # Create utime module as alias for time (MicroPython compatibility)
     if "utime" not in sys.modules:
-        # Use a monotonic clock to emulate MicroPython's ticks_* semantics
-        monotonic = getattr(time, "monotonic", time.perf_counter)
         utime = types.ModuleType("utime")
         utime.sleep_ms = time.sleep_ms
         utime.sleep_us = time.sleep_us
         utime.sleep = time.sleep
-        utime.ticks_ms = lambda: int(monotonic() * 1000)
-        utime.ticks_us = lambda: int(monotonic() * 1000000)
-        utime.ticks_diff = lambda a, b: a - b
+        utime.ticks_ms = time.ticks_ms
+        utime.ticks_us = time.ticks_us
+        utime.ticks_diff = time.ticks_diff
         sys.modules["utime"] = utime
 
     # Add driver lib path to sys.path

--- a/tests/scenarios/wsen_hids.yaml
+++ b/tests/scenarios/wsen_hids.yaml
@@ -1,0 +1,103 @@
+driver: wsen-hids
+module_name: wsen_hids
+driver_class: WSEN_HIDS
+i2c_address: 0x5F
+
+# I2C config for hardware tests (STeaMi board - STM32WB55)
+i2c:
+  id: 1
+
+# Register values for mock tests
+# These simulate a real WSEN-HIDS sensor with calibration data
+mock_registers:
+  # DEVICE_ID (expected 0xBC)
+  0x0F: 0xBC
+  # AV_CONF (AVG_T=16, AVG_H=16 -> (3 << 3) | 3 = 0x1B)
+  0x10: 0x1B
+  # CTRL_1 (power-down, BDU enabled)
+  0x20: 0x04
+  # CTRL_2 (default)
+  0x21: 0x00
+  # STATUS (humidity and temperature data available)
+  0x27: 0x03
+
+  # Calibration registers
+  # H0_RH_X2 = 60 -> H0_rH = 30.0 %
+  0x30: 0x3C
+  # H1_RH_X2 = 120 -> H1_rH = 60.0 %
+  0x31: 0x78
+  # T0_DEGC_X8 low byte = 0xA0 (T0_degC_x8 = 160 -> T0 = 20.0 C)
+  0x32: 0xA0
+  # T1_DEGC_X8 low byte = 0x18 (T1_degC_x8 = 280 -> T1 = 35.0 C)
+  0x33: 0x18
+  # T1_T0_MSB: bits[1:0]=T0 msb=0, bits[3:2]=T1 msb=1 -> 0x04
+  0x35: 0x04
+  # H0_T0_OUT (signed16 = 3000 = 0x0BB8)
+  0x36: [0xB8, 0x0B]
+  # H1_T0_OUT (signed16 = 9000 = 0x2328)
+  0x3A: [0x28, 0x23]
+  # T0_OUT (signed16 = 2000 = 0x07D0)
+  0x3C: [0xD0, 0x07]
+  # T1_OUT (signed16 = 5000 = 0x1388)
+  0x3E: [0x88, 0x13]
+
+  # Raw data via auto-increment read at 0xA8 (0x28 | 0x80)
+  # H_OUT_L, H_OUT_H, T_OUT_L, T_OUT_H
+  # h_raw = 7000 (-> 50.0 %RH), t_raw = 3000 (-> 25.0 C)
+  0xA8: [0x58, 0x1B, 0xB8, 0x0B]
+
+tests:
+  - name: "Verify device ID register"
+    action: read_register
+    register: 0x0F
+    expect: 0xBC
+    mode: [mock, hardware]
+
+  - name: "Read device ID via method"
+    action: call
+    method: device_id
+    expect: 0xBC
+    mode: [mock, hardware]
+
+  - name: "Read status register"
+    action: call
+    method: status
+    expect_not_none: true
+    mode: [mock, hardware]
+
+  - name: "Read humidity returns float"
+    action: call
+    method: humidity
+    expect_range: [49.0, 51.0]
+    mode: [mock]
+
+  - name: "Read temperature returns float"
+    action: call
+    method: temperature
+    expect_range: [24.0, 26.0]
+    mode: [mock]
+
+  - name: "Humidity in plausible range"
+    action: call
+    method: humidity
+    expect_range: [5.0, 100.0]
+    mode: [hardware]
+
+  - name: "Temperature in plausible range"
+    action: call
+    method: temperature
+    expect_range: [-10.0, 60.0]
+    mode: [hardware]
+
+  - name: "Humidity and temperature feel correct"
+    action: manual
+    display:
+      - method: humidity
+        label: "Humidity"
+        unit: "%RH"
+      - method: temperature
+        label: "Temperature"
+        unit: "°C"
+    prompt: "Ces valeurs sont-elles cohérentes (humidité ambiante, température ambiante) ?"
+    expect_true: true
+    mode: [hardware]


### PR DESCRIPTION
## Summary
- Add YAML test scenario `tests/scenarios/wsen_hids.yaml` for WSEN-HIDS driver
- Add `ticks_ms`, `ticks_us`, `ticks_diff` stubs to `time` module in executor (needed for drivers using `from time import ticks_ms`)
- Refactor `utime` stub to reuse `time` module stubs instead of duplicating logic

### Mock tests (5)
- Verify device ID register (0xBC)
- Read device ID via method
- Read status register
- Read humidity (~50.0 %RH from calibrated mock data)
- Read temperature (~25.0 °C from calibrated mock data)

### Hardware tests (2)
- Humidity in plausible range [5.0, 100.0] %RH
- Temperature in plausible range [-10.0, 60.0] °C

### Manual test (1)
- Verify displayed humidity and temperature values

## How to test

```bash
# Mock tests only
python3 -m pytest tests/ -v --driver wsen-hids

# Hardware tests (with STeaMi board connected)
python3 -m pytest tests/ -v --port /dev/ttyACM0 --driver wsen-hids -s
```

## Test results

```
$ python3 -m pytest tests/ -v --port /dev/ttyACM0 --driver wsen-hids -s
============================= test session starts ==============================
platform linux -- Python 3.13.7, pytest-8.3.5, pluggy-1.5.0

tests/test_scenarios.py::test_scenario[wsen-hids/Verify device ID register/mock] 0xBC
PASSED
tests/test_scenarios.py::test_scenario[wsen-hids/Verify device ID register/hardware] 0xBC
PASSED
tests/test_scenarios.py::test_scenario[wsen-hids/Read device ID via method/mock] 0xBC
PASSED
tests/test_scenarios.py::test_scenario[wsen-hids/Read device ID via method/hardware] 0xBC
PASSED
tests/test_scenarios.py::test_scenario[wsen-hids/Read status register/mock] 3
PASSED
tests/test_scenarios.py::test_scenario[wsen-hids/Read status register/hardware] 3
PASSED
tests/test_scenarios.py::test_scenario[wsen-hids/Read humidity returns float/mock] 50.00
PASSED
tests/test_scenarios.py::test_scenario[wsen-hids/Read temperature returns float/mock] 25.00
PASSED
tests/test_scenarios.py::test_scenario[wsen-hids/Humidity in plausible range/hardware] 36.17
PASSED
tests/test_scenarios.py::test_scenario[wsen-hids/Temperature in plausible range/hardware] 20.30
PASSED
tests/test_scenarios.py::test_scenario[wsen-hids/Humidity and temperature feel correct/hardware]   Humidity: 36.44 %RH
  Temperature: 20.30 °C
  [MANUAL] Ces valeurs sont-elles cohérentes (humidité ambiante, température ambiante) ? [y/n] y
True
PASSED

================================11 passed in 22.51s ================================

```

Resolves #39