### PR TITLE
lis2mdl: Fix magnitude range for hardware test.

### DIFF
--- a/tests/scenarios/lis2mdl.yaml
+++ b/tests/scenarios/lis2mdl.yaml
@@ -73,7 +73,7 @@ tests:
   - name: "Magnitude in plausible range"
     action: call
     method: magnitude_uT
-    expect_range: [10.0, 120.0]
+    expect_range: [10.0, 300.0]
     mode: [hardware]
 
   - name: "Temperature in plausible range"


### PR DESCRIPTION
Closes #34

## Summary
- Widen magnitude plausible range from [10, 120] to [10, 300] µT for hardware test
- The STeaMi board's buzzer magnet causes elevated readings (~160-190 µT)

## Test commands

```bash
# Mock tests (CPython)
python3 -m pytest tests/ -v --driver lis2mdl

# Hardware tests (STeaMi board)
python3 -m pytest tests/ -v --port /dev/ttyACM0 --driver lis2mdl -s
```

## Test results

```
tests/test_scenarios.py::test_scenario[lis2mdl/Verify WHO_AM_I register/mock] 0x40
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Verify WHO_AM_I register/hardware] 0x40
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read WHO_AM_I via method/mock] 0x40
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read WHO_AM_I via method/hardware] 0x40
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read status register/mock] 15
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read status register/hardware] 255
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read magnetic field returns tuple/mock] (300, -150, 450)
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read magnetic field in uT returns tuple/mock] (45.0, -22.5, 67.5)
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read temperature returns float/mock] 25.00
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Magnitude in plausible range/hardware] 163.51
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Temperature in plausible range/hardware] 2.12
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Magnetic field values feel correct/hardware] SKIPPED

======================== 11 passed, 1 skipped in 17.80s ========================
```