### PR TITLE
lis2mdl: Auto-trigger single conversion in idle mode.

### DIFF
--- a/lib/lis2mdl/lis2mdl/device.py
+++ b/lib/lis2mdl/lis2mdl/device.py
@@ -176,6 +176,7 @@ class LIS2MDL(object):
                 if self.data_ready():
                     return
                 sleep_ms(2)
+            raise OSError("LIS2MDL data ready timeout")
 
     def read_magnet_raw(self):
         """Reads the raw magnetic field (LSB). Same as read_magnet(), but more explicit."""

--- a/tests/scenarios/lis2mdl.yaml
+++ b/tests/scenarios/lis2mdl.yaml
@@ -106,6 +106,18 @@ tests:
     expect_true: true
     mode: [mock]
 
+  - name: "Auto-trigger writes single mode to CFG_REG_A"
+    action: script
+    script: |
+      dev.power_down()
+      i2c.clear_write_log()
+      dev.read_magnet()
+      log = i2c.get_write_log()
+      wrote_cfg_a = any(reg == 0x60 for reg, data in log)
+      result = wrote_cfg_a
+    expect_true: true
+    mode: [mock]
+
   - name: "No auto-trigger when already active"
     action: script
     script: |


### PR DESCRIPTION
Closes #70

## Summary

When the LIS2MDL is in idle mode (`power_down()` called), reading magnetic field or temperature data now automatically triggers a single conversion and waits for data ready, instead of returning stale values.

- `_ensure_data()` — checks `is_idle()`, sets mode to "single", polls `data_ready()` (up to 100ms)
- Called in `read_magnet()` and `read_temperature_raw()`
- All higher-level methods (`read_magnet_uT()`, `magnitude_uT()`, `read_temperature_c()`, `heading_flat_only()`, etc.) benefit automatically

Follows the same convention as WSEN-PADS, WSEN-HIDS, HTS221, and ISM330DL (#44).

## Test plan

### Mock tests (no hardware)

```bash
python3 -m pytest tests/ -k "lis2mdl and mock" -v
```

```
tests/test_scenarios.py::test_scenario[lis2mdl/Verify WHO_AM_I register/mock] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read WHO_AM_I via method/mock] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read status register/mock] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read magnetic field returns tuple/mock] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read magnetic field in uT returns tuple/mock] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read temperature returns float/mock] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Temperature with offset/mock] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Temperature with two-point calibration/mock] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Magnetic field readable after power down/mock] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Temperature readable after power down/mock] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/No auto-trigger when already active/mock] PASSED

11 passed
```

### Hardware tests (STeaMi board connected)

```bash
python3 -m pytest tests/ --port /dev/ttyACM0 -k "lis2mdl and hardware" -s -v
```

```
tests/test_scenarios.py::test_scenario[lis2mdl/Verify WHO_AM_I register/hardware] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read WHO_AM_I via method/hardware] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read status register/hardware] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Fresh magnitude after power down/hardware] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Fresh temperature after power down/hardware] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Magnitude in plausible range/hardware] PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Temperature in plausible range/hardware] PASSED

7 passed, 4 skipped
```