### PR TITLE
tests: Add board qualification test for I2C bus scan.

### DIFF
--- a/tests/scenarios/board_i2c_scan.yaml
+++ b/tests/scenarios/board_i2c_scan.yaml
@@ -14,9 +14,10 @@ tests:
       i2c = I2C(1)
       found = i2c.scan()
       # Expected I2C addresses on STeaMi board (7-bit):
-      # 0x20=MCP23009E, 0x29=VL53L1X, 0x39=APDS9960, 0x3B=STM32F103CB
-      # 0x55=BQ27441, 0x5D=WSEN-PADS, 0x5F=HTS221/WSEN-HIDS, 0x6B=ISM330DL
-      expected = [0x20, 0x29, 0x39, 0x3B, 0x55, 0x5D, 0x5F, 0x6B]
+      # 0x1E=LIS2MDL, 0x20=MCP23009E, 0x29=VL53L1X, 0x39=APDS9960
+      # 0x3B=STM32F103CB, 0x55=BQ27441, 0x5D=WSEN-PADS
+      # 0x5F=HTS221/WSEN-HIDS, 0x6B=ISM330DL
+      expected = [0x1E, 0x20, 0x29, 0x39, 0x3B, 0x55, 0x5D, 0x5F, 0x6B]
       missing = sorted([hex(a) for a in expected if a not in found])
       result = missing
     expect: []


### PR DESCRIPTION
## Summary

Closes #84
Depends on #89 (framework extension)

Adds a board qualification test scenario that scans the internal I2C bus, verifies all expected device addresses are present, and checks the WHO_AM_I / device ID register of each component.

### Scenario: `tests/scenarios/board_i2c_scan.yaml`

#### Bus scan tests (2 tests)
| Test | Description |
|------|-------------|
| I2C bus scan finds expected devices | Scans I2C(1) and verifies 9 expected addresses |
| No unexpected I2C devices | Verifies no unknown addresses on the bus |

#### WHO_AM_I / Device ID tests (7 tests)
| Test | Address | Register | Expected |
|------|---------|----------|----------|
| LIS2MDL WHO_AM_I | 0x1E | 0x4F | 0x40 |
| MCP23009E IODIR default | 0x20 | 0x00 | 0xFF |
| VL53L1X model ID | 0x29 | 0x010F | 0xEACC |
| APDS9960 device ID | 0x39 | 0x92 | 0xAB |
| WSEN-PADS device ID | 0x5D | 0x0F | 0xB3 |
| HTS221/WSEN-HIDS device ID | 0x5F | 0x0F | 0xBC |
| ISM330DL WHO_AM_I | 0x6B | 0x0F | 0x6A |

**Expected I2C addresses (7-bit):**
- `0x1E` LIS2MDL, `0x20` MCP23009E, `0x29` VL53L1X, `0x39` APDS9960
- `0x3B` STM32F103CB, `0x55` BQ27441, `0x5D` WSEN-PADS
- `0x5F` HTS221/WSEN-HIDS, `0x6B` ISM330DL

**Note:** MCP23009E requires releasing `RST_EXPANDER` pin before scan.

### How to test

```bash
# Mock tests (no regression)
pytest tests/ -k mock

# Collect board tests (no hardware needed)
pytest tests/ -k board_i2c_scan --collect-only

# Run on hardware (requires STeaMi board)
pytest tests/ --port /dev/ttyACM0 -k board_i2c_scan -s -v
```

## Test plan

- [x] `ruff check tests/` — passed
- [x] `pytest tests/ -k mock` — 41 passed (no regression)
- [x] Board tests correctly collected and skipped without `--port`
- [x] Hardware validation on STeaMi board — 9 passed