### PR TITLE
tests: Add board qualification tests for user LEDs.

### DIFF
--- a/tests/scenarios/board_leds.yaml
+++ b/tests/scenarios/board_leds.yaml
@@ -4,7 +4,7 @@ name: "board_leds"
 tests:
   - name: "LED RED on/off"
     action: hardware_script
-    pre_prompt: "Observez la LED RGB sur la carte, puis appuyez sur Entrée."
+    pre_prompt: "Appuyez sur Entrée pour lancer le test LED RGB, puis observez la carte."
     script: |
       from machine import Pin
       from time import sleep_ms
@@ -88,7 +88,7 @@ tests:
 
   - name: "LED BLE on/off"
     action: hardware_script
-    pre_prompt: "Observez la LED BLE, puis appuyez sur Entrée."
+    pre_prompt: "Appuyez sur Entrée pour lancer le test LED BLE, puis observez la carte."
     script: |
       from machine import Pin
       from time import sleep_ms


### PR DESCRIPTION
## Summary

Closes #85
Depends on #89 (framework extension)

Adds board qualification tests for the user RGB LED (red, green, blue) and BLE LED.

### Scenario: `tests/scenarios/board_leds.yaml`

| Test | Pin | Type |
|------|-----|------|
| LED RED on/off | `LED_RED` (PC12) | `hardware_script` |
| LED RED visible | — | `manual` |
| LED GREEN on/off | `LED_GREEN` (PC11) | `hardware_script` |
| LED GREEN visible | — | `manual` |
| LED BLUE on/off | `LED_BLUE` (PC10) | `hardware_script` |
| LED BLUE visible | — | `manual` |
| RGB LED full cycle | R→G→B→white | `hardware_script` |
| RGB LED full cycle visible | — | `manual` |
| LED BLE on/off | `LED_BLE` (PH3) | `hardware_script` |
| LED BLE visible | — | `manual` |

### How to test

```bash
# Mock tests (no regression)
pytest tests/ -k mock

# Collect LED board tests
pytest tests/ -k board_leds --collect-only

# Run on hardware (requires STeaMi board, interactive)
pytest tests/ --port /dev/ttyACM0 -k board_leds -s
```

## Test results

```
$ pytest tests/ -k mock -q
41 passed, 95 deselected

$ pytest tests/ -k board_leds --collect-only -q
10 tests collected (board_leds/LED RED on|off, LED RED visible, ..., LED BLE visible)

$ pytest tests/ -k board_leds -q  # (sans --port)
10 skipped  # correctly skipped without hardware

$ pytest tests/ --port /dev/ttyACM0 -k board_leds -s -v   
============================== test session starts ==============================
platform linux -- Python 3.13.7, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/nedjar/sandbox/micropython-steami-lib
configfile: pytest.ini
plugins: typeguard-4.4.2
collected 113 items / 103 deselected / 10 selected                                                                                                                                                                                                                          

tests/test_scenarios.py::test_scenario[board_leds/LED RED on/off/hardware]   [INTERACTIVE] Observez la LED rouge sur la carte, puis appuyez sur Entrée. 
True
PASSED
tests/test_scenarios.py::test_scenario[board_leds/LED RED visible/hardware]   [MANUAL] La LED rouge s'est-elle allumée puis éteinte ? [Entree=oui / Echap=non] 
True
PASSED
tests/test_scenarios.py::test_scenario[board_leds/LED GREEN on/off/hardware]   [INTERACTIVE] Observez la LED verte, puis appuyez sur Entrée. 

True
PASSED
tests/test_scenarios.py::test_scenario[board_leds/LED GREEN visible/hardware]   [MANUAL] La LED verte s'est-elle allumée puis éteinte ? [Entree=oui / Echap=non] 
True
PASSED
tests/test_scenarios.py::test_scenario[board_leds/LED BLUE on/off/hardware]   [INTERACTIVE] Observez la LED bleue, puis appuyez sur Entrée. 

True
PASSED
tests/test_scenarios.py::test_scenario[board_leds/LED BLUE visible/hardware]   [MANUAL] La LED bleue s'est-elle allumée puis éteinte ? [Entree=oui / Echap=non] 
True
PASSED
tests/test_scenarios.py::test_scenario[board_leds/RGB LED full cycle/hardware]   [INTERACTIVE] Observez la LED RGB (séquence R/G/B/blanc), puis appuyez sur Entrée. 

True
PASSED
tests/test_scenarios.py::test_scenario[board_leds/RGB LED full cycle visible/hardware]   [MANUAL] La LED a-t-elle affiché rouge, vert, bleu, puis blanc ? [Entree=oui / Echap=non] 
True
PASSED
tests/test_scenarios.py::test_scenario[board_leds/LED BLE on/off/hardware]   [INTERACTIVE] Observez la LED BLE, puis appuyez sur Entrée. 
True
PASSED
tests/test_scenarios.py::test_scenario[board_leds/LED BLE visible/hardware]   [MANUAL] La LED BLE (bleue) s'est-elle allumée puis éteinte ? [Entree=oui / Echap=non] 
True
PASSED

====================== 10 passed, 103 deselected in 37.75s ======================
```

Hardware test results will be added after board validation.

## Test plan

- [x] `ruff check tests/` — passed
- [x] `pytest tests/ -k mock` — 41 passed (no regression)
- [x] 10 LED board tests correctly collected and skipped without `--port`
- [x] Hardware validation on STeaMi board (pending)