### PR TITLE
tests: Add board qualification tests for A/B/Menu buttons.

### DIFF
--- a/tests/scenarios/board_buttons.yaml
+++ b/tests/scenarios/board_buttons.yaml
@@ -14,7 +14,10 @@ tests:
       from time import sleep_ms, ticks_ms, ticks_diff
       led = Pin("LED_GREEN", Pin.OUT)
       btn = Pin("A_BUTTON", Pin.IN, Pin.PULL_UP)
+      t_rel = ticks_ms()
       while btn.value() == 0:
+        if ticks_diff(ticks_ms(), t_rel) > 3000:
+          break
         sleep_ms(20)
       led.on()
       detected = False
@@ -38,7 +41,10 @@ tests:
       from time import sleep_ms, ticks_ms, ticks_diff
       led = Pin("LED_GREEN", Pin.OUT)
       btn = Pin("B_BUTTON", Pin.IN, Pin.PULL_UP)
+      t_rel = ticks_ms()
       while btn.value() == 0:
+        if ticks_diff(ticks_ms(), t_rel) > 3000:
+          break
         sleep_ms(20)
       led.on()
       detected = False
@@ -62,7 +68,10 @@ tests:
       from time import sleep_ms, ticks_ms, ticks_diff
       led = Pin("LED_GREEN", Pin.OUT)
       btn = Pin("MENU_BUTTON", Pin.IN, Pin.PULL_UP)
+      t_rel = ticks_ms()
       while btn.value() == 0:
+        if ticks_diff(ticks_ms(), t_rel) > 3000:
+          break
         sleep_ms(20)
       led.on()
       detected = False
@@ -77,7 +86,107 @@ tests:
     expect_true: true
     mode: [hardware]
 
-  # --- Interrupt tests (one per button) ---
+  # --- D-PAD buttons via MCP23009E (I2C 0x20, GPIO register 0x09) ---
+  # Read directly via I2C without importing the driver.
+  # Bit mapping: UP=bit7, DOWN=bit5, LEFT=bit6, RIGHT=bit4.
+
+  - name: "D-PAD UP press (polling)"
+    action: hardware_script
+    pre_prompt: "Test polling D-PAD : appuyez sur chaque bouton quand la LED verte s'allume (5s). Commençons par UP."
+    wait: false
+    script: |
+      from machine import Pin, I2C
+      from time import sleep_ms, ticks_ms, ticks_diff
+      led = Pin("LED_GREEN", Pin.OUT)
+      i2c = I2C(1)
+      bit = 7
+      led.on()
+      detected = False
+      t0 = ticks_ms()
+      while ticks_diff(ticks_ms(), t0) < 5000:
+        gpio = i2c.readfrom_mem(0x20, 0x09, 1)[0]
+        if not (gpio & (1 << bit)):
+          detected = True
+          break
+        sleep_ms(20)
+      led.off()
+      result = detected
+    expect_true: true
+    mode: [hardware]
+
+  - name: "D-PAD DOWN press (polling)"
+    action: hardware_script
+    pre_prompt: "Bouton DOWN"
+    wait: false
+    script: |
+      from machine import Pin, I2C
+      from time import sleep_ms, ticks_ms, ticks_diff
+      led = Pin("LED_GREEN", Pin.OUT)
+      i2c = I2C(1)
+      bit = 5
+      led.on()
+      detected = False
+      t0 = ticks_ms()
+      while ticks_diff(ticks_ms(), t0) < 5000:
+        gpio = i2c.readfrom_mem(0x20, 0x09, 1)[0]
+        if not (gpio & (1 << bit)):
+          detected = True
+          break
+        sleep_ms(20)
+      led.off()
+      result = detected
+    expect_true: true
+    mode: [hardware]
+
+  - name: "D-PAD LEFT press (polling)"
+    action: hardware_script
+    pre_prompt: "Bouton LEFT"
+    wait: false
+    script: |
+      from machine import Pin, I2C
+      from time import sleep_ms, ticks_ms, ticks_diff
+      led = Pin("LED_GREEN", Pin.OUT)
+      i2c = I2C(1)
+      bit = 6
+      led.on()
+      detected = False
+      t0 = ticks_ms()
+      while ticks_diff(ticks_ms(), t0) < 5000:
+        gpio = i2c.readfrom_mem(0x20, 0x09, 1)[0]
+        if not (gpio & (1 << bit)):
+          detected = True
+          break
+        sleep_ms(20)
+      led.off()
+      result = detected
+    expect_true: true
+    mode: [hardware]
+
+  - name: "D-PAD RIGHT press (polling)"
+    action: hardware_script
+    pre_prompt: "Bouton RIGHT"
+    wait: false
+    script: |
+      from machine import Pin, I2C
+      from time import sleep_ms, ticks_ms, ticks_diff
+      led = Pin("LED_GREEN", Pin.OUT)
+      i2c = I2C(1)
+      bit = 4
+      led.on()
+      detected = False
+      t0 = ticks_ms()
+      while ticks_diff(ticks_ms(), t0) < 5000:
+        gpio = i2c.readfrom_mem(0x20, 0x09, 1)[0]
+        if not (gpio & (1 << bit)):
+          detected = True
+          break
+        sleep_ms(20)
+      led.off()
+      result = detected
+    expect_true: true
+    mode: [hardware]
+
+  # --- Interrupt tests (GPIO direct buttons) ---
   # LED_GREEN signals when the board is ready; uses Pin.irq() to detect press.
 
   - name: "Button A press (interrupt)"
@@ -89,7 +198,10 @@ tests:
       from time import sleep_ms, ticks_ms, ticks_diff
       led = Pin("LED_GREEN", Pin.OUT)
       btn = Pin("A_BUTTON", Pin.IN, Pin.PULL_UP)
+      t_rel = ticks_ms()
       while btn.value() == 0:
+        if ticks_diff(ticks_ms(), t_rel) > 3000:
+          break
         sleep_ms(20)
       detected = False
       def on_press(pin):
@@ -117,7 +229,10 @@ tests:
       from time import sleep_ms, ticks_ms, ticks_diff
       led = Pin("LED_GREEN", Pin.OUT)
       btn = Pin("B_BUTTON", Pin.IN, Pin.PULL_UP)
+      t_rel = ticks_ms()
       while btn.value() == 0:
+        if ticks_diff(ticks_ms(), t_rel) > 3000:
+          break
         sleep_ms(20)
       detected = False
       def on_press(pin):
@@ -145,7 +260,10 @@ tests:
       from time import sleep_ms, ticks_ms, ticks_diff
       led = Pin("LED_GREEN", Pin.OUT)
       btn = Pin("MENU_BUTTON", Pin.IN, Pin.PULL_UP)
+      t_rel = ticks_ms()
       while btn.value() == 0:
+        if ticks_diff(ticks_ms(), t_rel) > 3000:
+          break
         sleep_ms(20)
       detected = False
       def on_press(pin):


### PR DESCRIPTION
## Summary

Closes #86
Depends on #89 (framework extension)

Adds board qualification tests for the A, B, and Menu buttons (directly connected to STM32WB55 GPIO, not via I/O expander).

**Note**: D-PAD buttons (UP/DOWN/LEFT/RIGHT) are already tested in `mcp23009e.yaml` via the MCP23009E I/O expander.

### Scenario: `tests/scenarios/board_buttons.yaml`

| Test | Pin | Type |
|------|-----|------|
| Button A press detection | `A_BUTTON` (PA7) | `hardware_script` (interactive) |
| Button B press detection | `B_BUTTON` (PA8) | `hardware_script` (interactive) |
| Button MENU press detection | `MENU_BUTTON` (PA0) | `hardware_script` (interactive) |

Each test lights up the green LED and polls the button for 5 seconds. The operator must press the button while the LED is on.

### How to test

```bash
# Mock tests (no regression)
pytest tests/ -k mock

# Collect button board tests
pytest tests/ -k board_buttons --collect-only

# Run on hardware (requires STeaMi board, interactive)
pytest tests/ --port /dev/ttyACM0 -k board_buttons -s
```

## Test results

```
$ pytest tests/ -k mock -q
41 passed, 95 deselected

$ pytest tests/ -k board_buttons --collect-only -q
3 tests collected (Button A, Button B, Button MENU)

$ pytest tests/ -k board_buttons -q  # (sans --port)
3 skipped  # correctly skipped without hardware

$ pytest tests/ --port /dev/ttyACM0 -k board_buttons -s -v
============================== test session starts ==============================
platform linux -- Python 3.13.7, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/nedjar/sandbox/micropython-steami-lib
configfile: pytest.ini
plugins: typeguard-4.4.2
collected 113 items / 103 deselected / 10 selected                                                                                                                                                                                                                          

tests/test_scenarios.py::test_scenario[board_buttons/Button A press (polling)/hardware]   [INTERACTIVE] Test polling boutons : appuyez sur chaque bouton quand la LED verte s'allume (5s). Commençons par A.
True
PASSED
tests/test_scenarios.py::test_scenario[board_buttons/Button B press (polling)/hardware]   [INTERACTIVE] Bouton B
True
PASSED
tests/test_scenarios.py::test_scenario[board_buttons/Button MENU press (polling)/hardware]   [INTERACTIVE] Bouton MENU
True
PASSED
tests/test_scenarios.py::test_scenario[board_buttons/D-PAD UP press (polling)/hardware]   [INTERACTIVE] Test polling D-PAD : appuyez sur chaque bouton quand la LED verte s'allume (5s). Commençons par UP.
True
PASSED
tests/test_scenarios.py::test_scenario[board_buttons/D-PAD DOWN press (polling)/hardware]   [INTERACTIVE] Bouton DOWN
True
PASSED
tests/test_scenarios.py::test_scenario[board_buttons/D-PAD LEFT press (polling)/hardware]   [INTERACTIVE] Bouton LEFT
True
PASSED
tests/test_scenarios.py::test_scenario[board_buttons/D-PAD RIGHT press (polling)/hardware]   [INTERACTIVE] Bouton RIGHT
True
PASSED
tests/test_scenarios.py::test_scenario[board_buttons/Button A press (interrupt)/hardware]   [INTERACTIVE] Test interrupt boutons : appuyez brièvement sur chaque bouton quand la LED verte s'allume (5s). Commençons par A.
True
PASSED
tests/test_scenarios.py::test_scenario[board_buttons/Button B press (interrupt)/hardware]   [INTERACTIVE] Bouton B
True
PASSED
tests/test_scenarios.py::test_scenario[board_buttons/Button MENU press (interrupt)/hardware]   [INTERACTIVE] Bouton MENU
True
PASSED

====================== 10 passed, 103 deselected in 14.76s ======================
```

Hardware test results will be added after board validation.

## Test plan

- [x] `ruff check tests/` — passed
- [x] `pytest tests/ -k mock` — 41 passed (no regression)
- [x] 3 button board tests correctly collected and skipped without `--port`
- [x] Hardware validation on STeaMi board (pending)