### PR TITLE
tests: Add mock tests for HTS221 auto-trigger after poweroff.

### DIFF
--- a/tests/runner/executor.py
+++ b/tests/runner/executor.py
@@ -118,6 +118,11 @@ def run_action(action, driver_instance):
 
     Returns the result value from the action.
     """
+    # Run optional setup steps before the main action
+    for step in action.get("setup", []):
+        method = getattr(driver_instance, step["method"])
+        method(*step.get("args", []))
+
     action_type = action["action"]
 
     if action_type == "call":

--- a/tests/scenarios/hts221.yaml
+++ b/tests/scenarios/hts221.yaml
@@ -85,6 +85,30 @@ tests:
     expect_not_none: true
     mode: [mock, hardware]
 
+  - name: "Auto-trigger temperature after poweroff"
+    action: call
+    setup:
+      - method: poweroff
+    method: temperature
+    expect_not_none: true
+    mode: [mock]
+
+  - name: "Auto-trigger humidity after poweroff"
+    action: call
+    setup:
+      - method: poweroff
+    method: humidity
+    expect_not_none: true
+    mode: [mock]
+
+  - name: "Auto-trigger read after one-shot mode"
+    action: call
+    setup:
+      - method: trigger_one_shot
+    method: read
+    expect_not_none: true
+    mode: [mock]
+
   - name: "Auto-trigger after poweroff"
     action: hardware_script
     script: |


### PR DESCRIPTION
## Summary

Closes #95.

- Add 3 mock tests exercising the `_ensure_data()` / `trigger_one_shot()` auto-trigger path:
  - `Auto-trigger temperature after poweroff` — calls `poweroff()` then `temperature()`
  - `Auto-trigger humidity after poweroff` — calls `poweroff()` then `humidity()`
  - `Auto-trigger read after one-shot mode` — calls `trigger_one_shot()` then `read()`
- Add `setup` support in `executor.py` `run_action()` — allows calling methods on the driver instance before the main test action

## Test plan

```bash
python3 -m pytest tests/ -k "hts221 and mock" -v
```

### Mock test results

```
tests/test_scenarios.py::test_scenario[hts221/Verify device ID/mock] PASSED
tests/test_scenarios.py::test_scenario[hts221/Read WHO_AM_I via method/mock] PASSED
tests/test_scenarios.py::test_scenario[hts221/Read temperature returns float/mock] PASSED
tests/test_scenarios.py::test_scenario[hts221/Read humidity returns float/mock] PASSED
tests/test_scenarios.py::test_scenario[hts221/Status register has data ready/mock] PASSED
tests/test_scenarios.py::test_scenario[hts221/Auto-trigger temperature after poweroff/mock] PASSED
tests/test_scenarios.py::test_scenario[hts221/Auto-trigger humidity after poweroff/mock] PASSED
tests/test_scenarios.py::test_scenario[hts221/Auto-trigger read after one-shot mode/mock] PASSED
8 passed
```

- [x] All mock tests pass (8/8 for HTS221, 44/44 total)
- [x] `ruff check` passes