### PR TITLE
wsen-hids: Fix missing AUTO_INCREMENT bit in multi-byte register reads.

### DIFF
--- a/lib/wsen-hids/wsen_hids/device.py
+++ b/lib/wsen-hids/wsen_hids/device.py
@@ -90,6 +90,8 @@ class WSEN_HIDS(object):
 
     def _read_regs(self, reg, length):
         try:
+            if length > 1:
+                reg |= AUTO_INCREMENT
             return self.i2c.readfrom_mem(self.address, reg, length)
         except OSError as exc:
             raise WSENHIDSCommunicationError(
@@ -220,7 +222,7 @@ class WSEN_HIDS(object):
 
     def _read_raw_humidity_temperature(self):
         # Multi-byte read with auto-increment bit set.
-        data = self._read_regs(REG_H_OUT_L | AUTO_INCREMENT, 4)
+        data = self._read_regs(REG_H_OUT_L, 4)
 
         h_raw = data[0] | (data[1] << 8)
         t_raw = data[2] | (data[3] << 8)

--- a/tests/scenarios/wsen_hids.yaml
+++ b/tests/scenarios/wsen_hids.yaml
@@ -32,14 +32,14 @@ mock_registers:
   0x33: 0x18
   # T1_T0_MSB: bits[1:0]=T0 msb=0, bits[3:2]=T1 msb=1 -> 0x04
   0x35: 0x04
-  # H0_T0_OUT (signed16 = 3000 = 0x0BB8)
-  0x36: [0xB8, 0x0B]
-  # H1_T0_OUT (signed16 = 9000 = 0x2328)
-  0x3A: [0x28, 0x23]
-  # T0_OUT (signed16 = 2000 = 0x07D0)
-  0x3C: [0xD0, 0x07]
-  # T1_OUT (signed16 = 5000 = 0x1388)
-  0x3E: [0x88, 0x13]
+  # H0_T0_OUT (signed16 = 3000 = 0x0BB8) — auto-increment read
+  0xB6: [0xB8, 0x0B]
+  # H1_T0_OUT (signed16 = 9000 = 0x2328) — auto-increment read
+  0xBA: [0x28, 0x23]
+  # T0_OUT (signed16 = 2000 = 0x07D0) — auto-increment read
+  0xBC: [0xD0, 0x07]
+  # T1_OUT (signed16 = 5000 = 0x1388) — auto-increment read
+  0xBE: [0x88, 0x13]
 
   # Raw data via auto-increment read at 0xA8 (0x28 | 0x80)
   # H_OUT_L, H_OUT_H, T_OUT_L, T_OUT_H


### PR DESCRIPTION
Closes #109

## Summary

- Fix `_read_regs()` to set `AUTO_INCREMENT` (bit 7) when reading more than 1 byte, as required by the WSEN-HIDS (HTS221-based) I2C protocol
- Remove redundant `| AUTO_INCREMENT` in `_read_raw_humidity_temperature()` (now handled centrally)
- Update mock register addresses to use auto-increment keys (`0xB6`, `0xBA`, `0xBC`, `0xBE`)

## Bug

Without the auto-increment bit, multi-byte reads return the same byte repeated. This corrupted all 16-bit calibration values (T0_OUT, T1_OUT, H0_T0_OUT, H1_T0_OUT), causing temperature to read ~6°C too low and humidity to be inaccurate.

## Hardware validation

Before fix:
```
HTS221:    T=26.39 C
WSEN-HIDS: T=20.31 C  ← ~6°C too low
WSEN-PADS: T=25.86 C
```

After fix:
```
HTS221:    T=31.22 C
WSEN-HIDS: T=31.33 C  ← now matches HTS221
WSEN-PADS: T=29.88 C
```

## Test plan

- [x] `ruff check` passes
- [x] `pytest tests/ -k mock` — 44/44 passed (no regressions)
- [x] Hardware: temperature and humidity now match HTS221 within ~0.1°C