### PR TITLE
lis2mdl: Add two-point temperature calibration.

### DIFF
--- a/lib/lis2mdl/lis2mdl/device.py
+++ b/lib/lis2mdl/lis2mdl/device.py
@@ -252,14 +252,11 @@ class LIS2MDL(object):
     def set_temp_offset(self, offset_c):
         """Set a temperature offset in °C (gain remains 1.0).
 
-        This replaces the default base offset (25 °C) with the given value.
-
         Args:
             offset_c: offset value in degrees Celsius.
         """
         self._temp_gain = 1.0
-        self._temp_offset = 0.0
-        self._temp_base_offset = float(offset_c)
+        self._temp_offset = float(offset_c)
 
     def calibrate_temperature(self, ref_low, measured_low, ref_high, measured_high):
         """Two-point calibration from reference measurements.

--- a/tests/scenarios/lis2mdl.yaml
+++ b/tests/scenarios/lis2mdl.yaml
@@ -73,9 +73,9 @@ tests:
   - name: "Temperature with offset"
     action: script
     script: |
-      dev.set_temp_offset(30.0)
+      dev.set_temp_offset(-2.0)
       result = dev.read_temperature_c()
-    expect: 30.0
+    expect_range: [22.0, 24.0]
     mode: [mock]
 
   - name: "Temperature with two-point calibration"


### PR DESCRIPTION
## Summary
- Add `calibrate_temperature()` method for two-point calibration (gain + offset)
- Separate hardware base offset (`_temp_base_offset = 25°C`) from user calibration (`_temp_gain`, `_temp_offset`)
- Update `set_temp_offset()` to reset gain to 1.0
- Add mock test scenarios for offset and two-point calibration

The LIS2MDL has a specific temperature model: `T = base_offset + raw / sensitivity` where
`base_offset` defaults to 25°C (empirical, not guaranteed by datasheet). The calibration
applies on top: `T_cal = gain * T_factory + offset`.

Closes #113

## Test plan

### Mock tests (CI)
```bash
python3 -m pytest tests/ -k "lis2mdl and mock" -v
```

### Hardware tests (STeaMi board)
```bash
python3 -m pytest tests/ --port /dev/ttyACM0 -k "lis2mdl and hardware" -s -v
```

- [x] `ruff check` passes
- [x] All mock tests pass (8 tests including 2 new calibration tests)
- [x] Hardware validation on STeaMi board

## Test results 

```
$ python3 -m pytest tests/ --port /dev/ttyACM0 -k "lis2mdl and hardware" -s -v

======================================================= test session starts ========================================================
platform linux -- Python 3.13.7, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/nedjar/sandbox/micropython-steami-lib
configfile: pytest.ini
plugins: typeguard-4.4.2
collected 161 items / 152 deselected / 9 selected                                                                                  

tests/test_scenarios.py::test_scenario[board_i2c_scan/LIS2MDL WHO_AM_I (0x1E)/hardware] 0x40
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Verify WHO_AM_I register/hardware] 0x40
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read WHO_AM_I via method/hardware] 0x40
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Read status register/hardware] 255
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Magnitude in plausible range/hardware] 204.70
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Temperature in plausible range/hardware] 24.38
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Soft reset then WHO_AM_I/hardware] 0x40
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Reboot then WHO_AM_I/hardware] 0x40
PASSED
tests/test_scenarios.py::test_scenario[lis2mdl/Magnetic field values feel correct/hardware]   Magnitude: 0.21 µT
  Temperature: 24.50 °C
  Heading: 202.57 °
  [MANUAL] Ces valeurs sont-elles cohérentes (magnitude ~25-65µT, cap 0-360°) ? [Entree=oui / Echap=non] 
PASSED

================================================ 9 passed, 152 deselected in 49.11s ================================================
```