### PR TITLE
hts221: Add two-point temperature calibration.

### DIFF
--- a/lib/hts221/hts221/device.py
+++ b/lib/hts221/hts221/device.py
@@ -16,15 +16,18 @@ class HTS221(object):
         self.writebuffer = bytearray(1)
         self.readbuffer = bytearray(1)
 
-        self.calibrate_temperature()
-        self.calibrate_humidity()
+        self._temp_gain = 1.0
+        self._temp_offset = 0.0
+
+        self._read_temperature_calibration()
+        self._read_humidity_calibration()
 
         # set av conf: T=4 H=8
         self.setAv(0x81)
         # set CTRL_REG1: PD=1 BDU=1 ODR=1
         self.setODR(0x85)
 
-    def calibrate_temperature(self):
+    def _read_temperature_calibration(self):
         # HTS221 Temp Calibration registers
         self.T0_OUT = int16(self._read_reg16(HTS221_T0_OUT_L))
         self.T1_OUT = int16(self._read_reg16(HTS221_T1_OUT_L))
@@ -33,7 +36,7 @@ class HTS221(object):
         self.T0_degC = (self._read_reg(HTS221_T0_degC_x8) + (t1 % 4) * 256) / 8
         self.T1_degC = (self._read_reg(HTS221_T1_degC_x8) + ((t1 % 16) / 4) * 256) / 8
 
-    def calibrate_humidity(self):
+    def _read_humidity_calibration(self):
         # HTS221 Humi Calibration registers
         self.H0_OUT = self._read_reg16(HTS221_H0_T0_OUT_L)
         self.H1_OUT = self._read_reg16(HTS221_H1_T0_OUT_L)
@@ -112,9 +115,10 @@ class HTS221(object):
     def temperature(self):
         self._ensure_data()
         t = self._read_reg16(HTS221_TEMP_OUT_L)
-        return self.T0_degC + (self.T1_degC - self.T0_degC) * (t - self.T0_OUT) / (
+        factory = self.T0_degC + (self.T1_degC - self.T0_degC) * (t - self.T0_OUT) / (
             self.T1_OUT - self.T0_OUT
         )
+        return self._temp_gain * factory + self._temp_offset
 
     # calculate Humidity
     def humidity(self):
@@ -132,10 +136,40 @@ class HTS221(object):
         humidity = self.H0_rH + (self.H1_rH - self.H0_rH) * (h - self.H0_OUT) / (
             self.H1_OUT - self.H0_OUT
         )
-        temperature = self.T0_degC + (self.T1_degC - self.T0_degC) * (t - self.T0_OUT) / (
+        factory = self.T0_degC + (self.T1_degC - self.T0_degC) * (t - self.T0_OUT) / (
             self.T1_OUT - self.T0_OUT
         )
+        temperature = self._temp_gain * factory + self._temp_offset
         return humidity, temperature
+
+    # Temperature calibration
+
+    def set_temp_offset(self, offset_c):
+        """Set a temperature offset in °C (gain remains 1.0).
+
+        Args:
+            offset_c: offset value in degrees Celsius.
+        """
+        self._temp_gain = 1.0
+        self._temp_offset = float(offset_c)
+
+    def calibrate_temperature(self, ref_low, measured_low, ref_high, measured_high):
+        """Two-point calibration from reference measurements.
+
+        Computes gain and offset so that the sensor reading is adjusted
+        to match reference values at two temperature points.
+
+        Args:
+            ref_low: reference temperature at the low point (°C).
+            measured_low: sensor reading at the low point (°C).
+            ref_high: reference temperature at the high point (°C).
+            measured_high: sensor reading at the high point (°C).
+        """
+        delta = float(measured_high - measured_low)
+        if delta == 0.0:
+            raise ValueError("measured_low and measured_high must differ")
+        self._temp_gain = float(ref_high - ref_low) / delta
+        self._temp_offset = float(ref_low) - self._temp_gain * float(measured_low)
 
     def get(self):
         h, t = self.read()

--- a/tests/scenarios/hts221.yaml
+++ b/tests/scenarios/hts221.yaml
@@ -109,6 +109,33 @@ tests:
     expect_not_none: true
     mode: [mock]
 
+  - name: "Temperature with offset"
+    action: script
+    script: |
+      dev.set_temp_offset(-2.0)
+      result = dev.temperature()
+    expect_not_none: true
+    mode: [mock]
+
+  - name: "Temperature with two-point calibration"
+    action: script
+    script: |
+      t_before = dev.temperature()
+      dev.calibrate_temperature(20.0, t_before, 30.0, t_before + 10.0)
+      result = dev.temperature()
+    expect_range: [19.0, 21.0]
+    mode: [mock]
+
+  - name: "Read applies temperature calibration"
+    action: script
+    script: |
+      dev.set_temp_offset(-2.0)
+      _, temp = dev.read()
+      t_no_offset = dev.temperature() + 2.0
+      result = abs(temp - (t_no_offset - 2.0)) < 0.1
+    expect_true: true
+    mode: [mock]
+
   - name: "Auto-trigger after poweroff"
     action: hardware_script
     script: |


### PR DESCRIPTION
## Summary
- Add `set_temp_offset()` and `calibrate_temperature()` methods for two-point calibration (gain + offset)
- Rename internal `calibrate_temperature()` / `calibrate_humidity()` to `_read_temperature_calibration()` / `_read_humidity_calibration()` to free the public name for user calibration
- Apply calibration in both `temperature()` and `read()`
- Add 3 mock test scenarios for offset, two-point calibration, and `read()` calibration

Closes #104

## Test plan

### Mock tests (CI)
```bash
python3 -m pytest tests/ -k "hts221 and mock" -v
```

### Hardware tests (STeaMi board)
```bash
python3 -m pytest tests/ --port /dev/ttyACM0 -k "hts221 and hardware" -s -v
```

- [x] `ruff check` passes
- [x] All mock tests pass (11 tests including 3 new calibration tests)
- [x] Hardware validation on STeaMi board

## Test results

```
$python3 -m pytest tests/ --port /dev/ttyACM0 -k "hts221 and hardware" -s -v

======================================================= test session starts ========================================================
platform linux -- Python 3.13.7, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/nedjar/sandbox/micropython-steami-lib
configfile: pytest.ini
plugins: typeguard-4.4.2
collected 162 items / 154 deselected / 8 selected                                                                                  

tests/test_scenarios.py::test_scenario[board_i2c_scan/HTS221/WSEN-HIDS device ID (0x5F)/hardware] 0xBC
PASSED
tests/test_scenarios.py::test_scenario[hts221/Verify device ID/hardware] 0xBC
PASSED
tests/test_scenarios.py::test_scenario[hts221/Read WHO_AM_I via method/hardware] 0xBC
PASSED
tests/test_scenarios.py::test_scenario[hts221/Temperature in plausible range/hardware] 24.09
PASSED
tests/test_scenarios.py::test_scenario[hts221/Humidity in plausible range/hardware] 65.43
PASSED
tests/test_scenarios.py::test_scenario[hts221/Status register has data ready/hardware] 3
PASSED
tests/test_scenarios.py::test_scenario[hts221/Auto-trigger after poweroff/hardware] PASSED
tests/test_scenarios.py::test_scenario[hts221/Temperature feels correct/hardware]   Temperature: 24.35 °C
  Humidity: 64.54 %
  [MANUAL] Ces valeurs sont-elles cohérentes avec l'ambiance ? [Entree=oui / Echap=non] 
PASSED

================================================ 8 passed, 154 deselected in 19.08s ================================================
```