### PR TITLE
tests: Add calibration test to temperature comparison.

### DIFF
--- a/tests/scenarios/board_temperature_comparison.yaml
+++ b/tests/scenarios/board_temperature_comparison.yaml
@@ -100,7 +100,7 @@ tests:
     expect_true: true
     mode: [hardware]
 
-  - name: "Calibrate all sensors to WSEN-HIDS reference"
+  - name: "Offset-align all sensors to WSEN-HIDS reference"
     action: hardware_script
     script: |
       import sys
@@ -114,29 +114,34 @@ tests:
 
       i2c = I2C(1)
 
-      # Use WSEN-HIDS as the reference thermometer
+      # Initialize all sensors
       from wsen_hids.device import WSEN_HIDS
       ref = WSEN_HIDS(i2c)
-      ref_t = ref.temperature()
 
-      # Read raw values from each sensor before calibration
       from hts221.device import HTS221
       hts = HTS221(i2c)
       hts.poweroff()
       sleep_ms(20)
       hts.poweron()
       sleep_ms(50)
-      hts_t = hts.temperature()
 
       from wsen_pads.device import WSEN_PADS
       pads = WSEN_PADS(i2c)
-      pads_t = pads.temperature()
 
       from lis2mdl.device import LIS2MDL
       mag = LIS2MDL(i2c)
+
+      # Read reference just before each sensor to minimize drift
+      ref_t = ref.temperature()
+      hts_t = hts.temperature()
+
+      ref_t2 = ref.temperature()
+      pads_t = pads.temperature()
+
+      ref_t3 = ref.temperature()
       mag_t = mag.read_temperature_c()
 
-      print('--- Before calibration ---')
+      print('--- Before offset alignment ---')
       print('  WSEN-HIDS (ref): ' + str(round(ref_t, 2)) + ' C')
       print('  HTS221:          ' + str(round(hts_t, 2)) + ' C')
       print('  WSEN-PADS:       ' + str(round(pads_t, 2)) + ' C')
@@ -145,35 +150,34 @@ tests:
       spread_before = max(hts_t, pads_t, mag_t, ref_t) - min(hts_t, pads_t, mag_t, ref_t)
       print('  Spread: ' + str(round(spread_before, 2)) + ' C')
 
-      # Calibrate each sensor using two-point method
-      # Use a synthetic second point: measured+10 -> ref+10
-      hts.calibrate_temperature(ref_t, hts_t, ref_t + 10.0, hts_t + 10.0)
-      pads.calibrate_temperature(ref_t, pads_t, ref_t + 10.0, pads_t + 10.0)
-      mag.calibrate_temperature(ref_t, mag_t, ref_t + 10.0, mag_t + 10.0)
+      # Apply offset to align each sensor to the reference reading
+      hts.set_temp_offset(ref_t - hts_t)
+      pads.set_temp_offset(ref_t2 - pads_t)
+      mag.set_temp_offset(ref_t3 - mag_t)
 
-      # Re-read after calibration
+      # Re-read after offset alignment
       sleep_ms(50)
-      ref_t2 = ref.temperature()
+      ref_t4 = ref.temperature()
       hts_t2 = hts.temperature()
       pads_t2 = pads.temperature()
       mag_t2 = mag.read_temperature_c()
 
-      print('--- After calibration ---')
-      print('  WSEN-HIDS (ref): ' + str(round(ref_t2, 2)) + ' C')
+      print('--- After offset alignment ---')
+      print('  WSEN-HIDS (ref): ' + str(round(ref_t4, 2)) + ' C')
       print('  HTS221:          ' + str(round(hts_t2, 2)) + ' C')
       print('  WSEN-PADS:       ' + str(round(pads_t2, 2)) + ' C')
       print('  LIS2MDL:         ' + str(round(mag_t2, 2)) + ' C')
 
-      spread_after = max(hts_t2, pads_t2, mag_t2, ref_t2) - min(hts_t2, pads_t2, mag_t2, ref_t2)
+      spread_after = max(hts_t2, pads_t2, mag_t2, ref_t4) - min(hts_t2, pads_t2, mag_t2, ref_t4)
       print('  Spread: ' + str(round(spread_after, 2)) + ' C')
 
-      # After calibration, spread should be < 2°C
+      # After alignment, spread should be < 2°C
       result = spread_after < 2.0
     expect_true: true
     mode: [hardware]
 
   - name: "Temperature values feel correct"
     action: manual
-    prompt: "Les températures calibrées sont-elles cohérentes entre elles et avec l'ambiance ?"
+    prompt: "Les températures lues sont-elles cohérentes entre elles et avec l'ambiance ?"
     expect_true: true
     mode: [hardware]


### PR DESCRIPTION
## Summary
- Add a new hardware test that calibrates all temperature sensors (HTS221, WSEN-PADS, LIS2MDL) against WSEN-HIDS as reference
- Uses two-point calibration with a synthetic second point (`measured + 10 → ref + 10`)
- Prints before/after comparison table and spread
- Verifies that post-calibration spread is < 2°C (vs < 8°C before calibration)
- Update manual check prompt to reference calibrated values

Closes #117

## Test plan

### Hardware test (STeaMi board)
```bash
python3 -m pytest tests/ --port /dev/ttyACM0 -k "Temperature and comparison" -s -v
```

- [x] All mock tests pass (54/54, this scenario is hardware-only)
- [x] Hardware validation on STeaMi board

## Test results

```
$ python3 -m pytest tests/ --port /dev/ttyACM0 -k "Temperature and comparison" -s -v


======================================================= test session starts ========================================================
platform linux -- Python 3.13.7, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/nedjar/sandbox/micropython-steami-lib
configfile: pytest.ini
plugins: typeguard-4.4.2
collected 168 items / 164 deselected / 4 selected                                                                                  

tests/test_scenarios.py::test_scenario[Temperature comparison (all sensors)/Read all temperature sensors/hardware] --- Temperature Comparison ---
  LIS2MDL     : 25.12 C
  WSEN-HIDS   : 28.43 C
  WSEN-PADS   : 26.86 C
  HTS221      : 28.54 C
  Spread: 1.68 C
PASSED
tests/test_scenarios.py::test_scenario[Temperature comparison (all sensors)/Temperature spread with barometer/hardware] HTS221: 28.54 C  |  WSEN-PADS: 26.86 C  |  Spread: 1.68 C
PASSED
tests/test_scenarios.py::test_scenario[Temperature comparison (all sensors)/Calibrate all sensors to WSEN-HIDS reference/hardware] --- Before calibration ---
  WSEN-HIDS (ref): 28.24 C
  HTS221:          28.39 C
  WSEN-PADS:       26.85 C
  LIS2MDL:         25.12 C
  Spread: 3.26 C
--- After calibration ---
  WSEN-HIDS (ref): 28.43 C
  HTS221:          28.28 C
  WSEN-PADS:       28.24 C
  LIS2MDL:         28.24 C
  Spread: 0.19 C
PASSED
tests/test_scenarios.py::test_scenario[Temperature comparison (all sensors)/Temperature values feel correct/hardware]   [MANUAL] Les températures calibrées sont-elles cohérentes entre elles et avec l'ambiance ? [Entree=oui / Echap=non] 
PASSED

=========================================== 4 passed, 164 deselected in 86.26s (0:01:26) ===========================================
```