### PR TITLE
tests: Add ISM330DL temperature to multidriver comparison scenario.

### DIFF
--- a/tests/scenarios/board_temperature_comparison.yaml
+++ b/tests/scenarios/board_temperature_comparison.yaml
@@ -57,6 +57,7 @@ tests:
       # ISM330DL (auxiliary, offset not guaranteed by datasheet)
       from ism330dl.device import ISM330DL
       imu = ISM330DL(i2c)
+      sleep_ms(200)  # stabilize after reset
       temps['ISM330DL'] = imu.temperature_c()
 
       # Print comparison table
@@ -141,6 +142,7 @@ tests:
 
       from ism330dl.device import ISM330DL
       imu = ISM330DL(i2c)
+      sleep_ms(200)  # stabilize after reset
 
       # Read reference just before each sensor to minimize drift
       ref_t = ref.temperature()


### PR DESCRIPTION
Closes #101

## Summary

Add ISM330DL temperature sensor to the multidriver temperature comparison scenario:

- Added `ism330dl` to the `drivers` list
- Added ISM330DL temperature reading to the "Read all temperature sensors" test
- Added ISM330DL to the "Offset-align all sensors" test (uses `set_temp_offset()` from #121)

## Depends on

- PR #121 (ISM330DL temperature calibration methods)

## Test plan

- [x] Run hardware temperature comparison tests with STeaMi board connected:

  ```bash
  python3 -m pytest tests/ --port /dev/ttyACM0 -k "temperature and comparison" -s -v
  ```

## Test results

```
======================================================= test session starts ========================================================
platform linux -- Python 3.13.7, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/nedjar/sandbox/micropython-steami-lib
configfile: pytest.ini
plugins: typeguard-4.4.2
collected 199 items / 195 deselected / 4 selected                                                                                  

tests/test_scenarios.py::test_scenario[Temperature comparison (all sensors)/Read all temperature sensors/hardware] --- Temperature Comparison ---
  WSEN-HIDS   : 27.97 C
  LIS2MDL     : 24.5 C
  WSEN-PADS   : 25.61 C
  HTS221      : 27.82 C
  ISM330DL    : 26.04 C
  Spread: 2.36 C
PASSED
tests/test_scenarios.py::test_scenario[Temperature comparison (all sensors)/Temperature spread with barometer/hardware] HTS221: 27.97 C  |  WSEN-PADS: 27.06 C  |  Spread: 0.91 C
PASSED
tests/test_scenarios.py::test_scenario[Temperature comparison (all sensors)/Offset-align all sensors to WSEN-HIDS reference/hardware] --- Before offset alignment ---
  WSEN-HIDS (ref): 27.79 C
  HTS221:          27.79 C
  WSEN-PADS:       27.11 C
  LIS2MDL:         24.5 C
  ISM330DL:        26.08 C
  Spread: 3.29 C
--- After offset alignment ---
  WSEN-HIDS (ref): 27.79 C
  HTS221:          27.79 C
  WSEN-PADS:       27.79 C
  LIS2MDL:         27.79 C
  ISM330DL:        27.79 C
  Spread: 0.0 C
PASSED
tests/test_scenarios.py::test_scenario[Temperature comparison (all sensors)/Temperature values feel correct/hardware]   [MANUAL] Les températures lues sont-elles cohérentes entre elles et avec l'ambiance ? [Entree=oui / Echap=non] 
PASSED

================================================ 4 passed, 195 deselected in 43.00s ================================================

```