### PR TITLE
ism330dl: Use polling with timeout in _ensure_data().

### DIFF
--- a/lib/ism330dl/ism330dl/device.py
+++ b/lib/ism330dl/ism330dl/device.py
@@ -137,9 +137,9 @@ class ISM330DL(object):
         if self._is_power_down():
             self.configure_accel(self._accel_odr, self._accel_scale)
             self.configure_gyro(self._gyro_odr, self._gyro_scale)
+            ready_mask = STATUS_XLDA | STATUS_GDA | STATUS_TDA
             for _ in range(50):
-                s = self._read_u8(REG_STATUS_REG)
-                if s & STATUS_XLDA:
+                if (self._read_u8(REG_STATUS_REG) & ready_mask) == ready_mask:
                     return
                 sleep_ms(10)
             raise OSError("ISM330DL data ready timeout")

--- a/tests/scenarios/ism330dl.yaml
+++ b/tests/scenarios/ism330dl.yaml
@@ -375,6 +375,20 @@ tests:
     expect_true: true
     mode: [mock]
 
+  - name: "Timeout raises OSError when data never ready"
+    action: script
+    script: |
+      dev.power_down()
+      i2c._registers[0x1E] = bytes([0x00])
+      try:
+          dev.acceleration_raw()
+          result = False
+      except OSError:
+          result = True
+      i2c._registers[0x1E] = bytes([0x07])
+    expect_true: true
+    mode: [mock]
+
   - name: "Fresh acceleration after power down"
     action: script
     script: |


### PR DESCRIPTION
Closes #125

## Summary

Replace `sleep_ms(100)` with polling of `STATUS_REG` for `XLDA` bit and `OSError` on timeout, consistent with the pattern used by WSEN-HIDS, LIS2MDL, VL53L1X, and APDS9960.

## Test plan

```bash
python3 -m pytest tests/ -k "ism330dl and mock" -v  # 31 passed
```