### PR TITLE
wsen-pads: Add data ready polling in _ensure_data().

### DIFF
--- a/lib/wsen-pads/wsen_pads/device.py
+++ b/lib/wsen-pads/wsen_pads/device.py
@@ -220,11 +220,12 @@ class WSEN_PADS(object):
         """Trigger a one-shot conversion if the sensor is in power-down mode."""
         if self._is_power_down():
             self.trigger_one_shot()
+            ready_mask = STATUS_P_DA | STATUS_T_DA
             for _ in range(50):
-                if self._read_reg(REG_STATUS) & STATUS_P_DA:
+                if (self._read_reg(REG_STATUS) & ready_mask) == ready_mask:
                     return
                 sleep_ms(2)
-            raise OSError("WSEN-PADS data ready timeout")
+            raise WSENPADSTimeout("WSEN-PADS data ready timeout")
 
     def pressure_raw(self):
         """

--- a/tests/scenarios/wsen_pads.yaml
+++ b/tests/scenarios/wsen_pads.yaml
@@ -83,6 +83,20 @@ tests:
     expect_range: [22.0, 24.0]
     mode: [mock]
 
+  - name: "Timeout raises exception when data never ready"
+    action: script
+    script: |
+      dev.power_down()
+      i2c._registers[0x27] = bytes([0x00])
+      try:
+          dev.pressure()
+          result = False
+      except Exception:
+          result = True
+      i2c._registers[0x27] = bytes([0x03])
+    expect_true: true
+    mode: [mock]
+
   - name: "Pressure in plausible range"
     action: call
     method: pressure


### PR DESCRIPTION
Closes #126

## Summary

Replace silent fallthrough after `trigger_one_shot()` with polling of `STATUS_P_DA` bit and `OSError` on timeout, consistent with WSEN-HIDS, LIS2MDL, VL53L1X, APDS9960, and ISM330DL.

## Test plan

```bash
python3 -m pytest tests/ -k "wsen-pads" -v  # 8 passed
```