### PR TITLE
hts221: Add data ready polling in _ensure_data().

### DIFF
--- a/lib/hts221/hts221/device.py
+++ b/lib/hts221/hts221/device.py
@@ -110,8 +110,9 @@ class HTS221(object):
     def _ensure_data(self):
         if self._is_power_down() or self._is_one_shot_mode():
             self.trigger_one_shot()
+            ready_mask = HTS221_STATUS_T_DA | HTS221_STATUS_H_DA
             for _ in range(50):
-                if self._read_reg(HTS221_STATUS_REG) & HTS221_STATUS_T_DA:
+                if (self._read_reg(HTS221_STATUS_REG) & ready_mask) == ready_mask:
                     return
                 sleep_ms(2)
             raise OSError("HTS221 data ready timeout")

--- a/tests/scenarios/hts221.yaml
+++ b/tests/scenarios/hts221.yaml
@@ -136,6 +136,20 @@ tests:
     expect_true: true
     mode: [mock]
 
+  - name: "Timeout raises OSError when data never ready"
+    action: script
+    script: |
+      dev.poweroff()
+      i2c._registers[0x27] = bytes([0x00])
+      try:
+          dev.temperature()
+          result = False
+      except OSError:
+          result = True
+      i2c._registers[0x27] = bytes([0x03])
+    expect_true: true
+    mode: [mock]
+
   - name: "Auto-trigger after poweroff"
     action: hardware_script
     script: |


### PR DESCRIPTION
Closes #127

## Summary

Add polling of `STATUS_T_DA` bit after `trigger_one_shot()` with `OSError` on timeout, consistent with WSEN-HIDS, LIS2MDL, VL53L1X, APDS9960, and ISM330DL.

## Test plan

```bash
python3 -m pytest tests/ -k "hts221 and mock" -v  # 11 passed
```