### PR TITLE
hts221: Migrate camelCase methods to snake_case.

### DIFF
--- a/lib/hts221/hts221/device.py
+++ b/lib/hts221/hts221/device.py
@@ -23,9 +23,9 @@ class HTS221(object):
         self._read_humidity_calibration()
 
         # set av conf: T=4 H=8
-        self.setAv(0x81)
+        self.set_av(0x81)
         # set CTRL_REG1: PD=1 BDU=1 ODR=1
-        self.setODR(0x85)
+        self.set_odr(0x85)
 
     def _read_temperature_calibration(self):
         # HTS221 Temp Calibration registers
@@ -57,7 +57,7 @@ class HTS221(object):
         return (higherByte << 8) + lowerByte
 
     # Device identification
-    def whoAmI(self):
+    def who_am_i(self):
         return self._read_reg(HTS221_WHO_AM_I)
 
     # get STATUS register
@@ -65,27 +65,27 @@ class HTS221(object):
         return self._read_reg(HTS221_STATUS_REG)
 
     # power control
-    def poweroff(self):
+    def power_off(self):
         t = self._read_reg(HTS221_CTRL_REG1) & 0x7F
         self._write_reg(HTS221_CTRL_REG1, t)
 
-    def poweron(self):
+    def power_on(self):
         t = self._read_reg(HTS221_CTRL_REG1) | 0x80
         self._write_reg(HTS221_CTRL_REG1, t)
 
     # get/set Output data rate
-    def getODR(self):
+    def get_odr(self):
         return self._read_reg(HTS221_CTRL_REG1) & 0x03
 
-    def setODR(self, odr=0):
+    def set_odr(self, odr=0):
         t = self._read_reg(HTS221_CTRL_REG1) & 0xFC
         self._write_reg(HTS221_CTRL_REG1, t | odr)
 
     # get/set Humidity and temperature average configuration
-    def getAv(self):
+    def get_av(self):
         return self._read_reg(HTS221_AV_CONF)
 
-    def setAv(self, av=0):
+    def set_av(self, av=0):
         self._write_reg(HTS221_AV_CONF, av)
 
     # one-shot / auto-trigger helpers

--- a/tests/scenarios/board_temperature_comparison.yaml
+++ b/tests/scenarios/board_temperature_comparison.yaml
@@ -33,9 +33,9 @@ tests:
       # HTS221
       from hts221.device import HTS221
       hts = HTS221(i2c)
-      hts.poweroff()
+      hts.power_off()
       sleep_ms(20)
-      hts.poweron()
+      hts.power_on()
       sleep_ms(50)
       temps['HTS221'] = hts.temperature()
 
@@ -92,9 +92,9 @@ tests:
 
       from hts221.device import HTS221
       hts = HTS221(i2c)
-      hts.poweroff()
+      hts.power_off()
       sleep_ms(20)
-      hts.poweron()
+      hts.power_on()
       sleep_ms(50)
       t_hts = hts.temperature()
 
@@ -129,9 +129,9 @@ tests:
 
       from hts221.device import HTS221
       hts = HTS221(i2c)
-      hts.poweroff()
+      hts.power_off()
       sleep_ms(20)
-      hts.poweron()
+      hts.power_on()
       sleep_ms(50)
 
       from wsen_pads.device import WSEN_PADS

--- a/tests/scenarios/hts221.yaml
+++ b/tests/scenarios/hts221.yaml
@@ -51,7 +51,7 @@ tests:
 
   - name: "Read WHO_AM_I via method"
     action: call
-    method: whoAmI
+    method: who_am_i
     expect: 0xBC
     mode: [mock, hardware]
 
@@ -88,7 +88,7 @@ tests:
   - name: "Auto-trigger temperature after poweroff"
     action: call
     setup:
-      - method: poweroff
+      - method: power_off
     method: temperature
     expect_not_none: true
     mode: [mock]
@@ -96,7 +96,7 @@ tests:
   - name: "Auto-trigger humidity after poweroff"
     action: call
     setup:
-      - method: poweroff
+      - method: power_off
     method: humidity
     expect_not_none: true
     mode: [mock]
@@ -139,7 +139,7 @@ tests:
   - name: "Timeout raises OSError when data never ready"
     action: script
     script: |
-      dev.poweroff()
+      dev.power_off()
       i2c._registers[0x27] = bytes([0x00])
       try:
           dev.temperature()
@@ -157,7 +157,7 @@ tests:
       from hts221.device import HTS221
       i2c = I2C(1)
       sensor = HTS221(i2c)
-      sensor.poweroff()
+      sensor.power_off()
       t = sensor.temperature()
       result = 10.0 <= t <= 45.0
     expect_true: true


### PR DESCRIPTION
Closes #131

## Summary

Rename all camelCase public methods to snake_case:

| Before | After |
|--------|-------|
| `whoAmI()` | `who_am_i()` |
| `poweroff()` | `power_off()` |
| `poweron()` | `power_on()` |
| `getODR()` | `get_odr()` |
| `setODR(odr)` | `set_odr(odr)` |
| `getAv()` | `get_av()` |
| `setAv(av)` | `set_av(av)` |

Also updates test scenarios (`hts221.yaml`, `board_temperature_comparison.yaml`) to use new names.

No backward-compatibility aliases (no release has been made yet).

## Test plan

### Mock tests

```bash
python3 -m pytest tests/ -k "hts221 and mock" -v  # 12 passed
```

### Hardware tests

```bash
python3 -m pytest tests/ --port /dev/ttyACM0 -k "hts221 and hardware" -s -v
```