### PR TITLE
ci: Enable ruff rules to enforce snake_case method naming.

### DIFF
--- a/lib/bq27441/bq27441/device.py
+++ b/lib/bq27441/bq27441/device.py
@@ -77,7 +77,7 @@ class BQ27441(object):
     def __init__(
         self,
         i2c,
-        capacity_mAh=LIPO_BATTERY_CAPACITY,
+        capacity_mAh=LIPO_BATTERY_CAPACITY,  # noqa: N803
         address=BQ27441_I2C_ADDRESS,
         gpout_pin=None,
     ):

--- a/lib/hts221/hts221/device.py
+++ b/lib/hts221/hts221/device.py
@@ -52,9 +52,9 @@ class HTS221(object):
         return self.readbuffer[0]
 
     def _read_reg16(self, reg):
-        lowerByte = self._read_reg(reg)
-        higherByte = self._read_reg(reg + 1)
-        return (higherByte << 8) + lowerByte
+        lo = self._read_reg(reg)
+        hi = self._read_reg(reg + 1)
+        return (hi << 8) + lo
 
     # Device identification
     def who_am_i(self):

--- a/lib/lis2mdl/lis2mdl/device.py
+++ b/lib/lis2mdl/lis2mdl/device.py
@@ -203,7 +203,7 @@ class LIS2MDL(object):
 
     _MAG_LSB_TO_uT = 0.15  # 1.5 mG/LSB ≈ 0.15 µT/LSB
 
-    def read_magnet_uT(self):
+    def read_magnet_uT(self):  # noqa: N802
         """Reads the magnetic field in µT, uncalibrated (simple conversion from LSB)."""
         x, y, z = self.read_magnet()
         return (
@@ -220,7 +220,7 @@ class LIS2MDL(object):
         z = (z - self.z_off) / self.z_scale
         return (x, y, z)
 
-    def magnitude_uT(self) -> float:
+    def magnitude_uT(self) -> float:  # noqa: N802
         """Total magnetic field strength (µT)."""
         x, y, z = self.read_magnet_uT()
         return math.sqrt(x * x + y * y + z * z)
@@ -328,11 +328,11 @@ class LIS2MDL(object):
     def read_all(self) -> dict:
         """Grouped reading useful for debug & logs."""
         raw = self.read_magnet_raw()
-        uT = self.read_magnet_uT()
+        mag_ut = self.read_magnet_uT()
         cal = self.read_magnet_calibrated_norm()
-        T = self.read_temperature_c()
+        temp = self.read_temperature_c()
         st = self.read_status()
-        return {"raw": raw, "uT": uT, "cal_norm": cal, "tempC": T, "status": st}
+        return {"raw": raw, "uT": mag_ut, "cal_norm": cal, "tempC": temp, "status": st}
 
     ##
     #  --- CALIBRATIONS ---
@@ -508,9 +508,9 @@ class LIS2MDL(object):
             self._hf_cos = (1.0 - a) * self._hf_cos + a * c
             self._hf_sin = (1.0 - a) * self._hf_sin + a * s
             # light normalization to avoid amplitude drift
-            NORMALIZATION_THRESHOLD = 1e-6
+            norm_threshold = 1e-6
             norm = math.sqrt(self._hf_cos * self._hf_cos + self._hf_sin * self._hf_sin)
-            if norm > NORMALIZATION_THRESHOLD:
+            if norm > norm_threshold:
                 self._hf_cos /= norm
                 self._hf_sin /= norm
         ang = math.degrees(math.atan2(self._hf_sin, self._hf_cos))
@@ -556,13 +556,13 @@ class LIS2MDL(object):
         roll = math.atan2(ay, az)
         pitch = math.atan2(-ax, math.sqrt(ay * ay + az * az))
         # straighten the magnetic vector
-        Xh = x * math.cos(pitch) + z * math.sin(pitch)
-        Yh = (
+        xh = x * math.cos(pitch) + z * math.sin(pitch)
+        yh = (
             x * math.sin(roll) * math.sin(pitch)
             + y * math.cos(roll)
             - z * math.sin(roll) * math.cos(pitch)
         )
-        ang = math.degrees(math.atan2(Yh, Xh))  # atan2(Yh, Xh)
+        ang = math.degrees(math.atan2(yh, xh))
         ang = self._apply_heading_offsets(ang)
         return self._filter_heading(ang)
 

--- a/lib/ssd1327/examples/rotating_3d_cube.py
+++ b/lib/ssd1327/examples/rotating_3d_cube.py
@@ -27,7 +27,7 @@ p2y = [0, 0, 0, 0, 0, 0, 0, 0]
 r = [0, 0, 0]
 
 
-def drawCube():
+def draw_cube():
     r[0] = r[0] + pi / 180.0
     r[1] = r[1] + pi / 180.0
     r[2] = r[2] + pi / 180.0
@@ -70,4 +70,4 @@ def drawCube():
 
 
 while True:
-    drawCube()
+    draw_cube()

--- a/lib/wsen-hids/wsen_hids/device.py
+++ b/lib/wsen-hids/wsen_hids/device.py
@@ -144,20 +144,20 @@ class WSEN_HIDS(object):
     def _read_calibration(self):
         h0_rh_x2 = self._read_reg(REG_H0_RH_X2)
         h1_rh_x2 = self._read_reg(REG_H1_RH_X2)
-        t0_degC_x8_lsb = self._read_reg(REG_T0_DEGC_X8)
-        t1_degC_x8_lsb = self._read_reg(REG_T1_DEGC_X8)
+        t0_degc_x8_lsb = self._read_reg(REG_T0_DEGC_X8)
+        t1_degc_x8_lsb = self._read_reg(REG_T1_DEGC_X8)
         t1_t0_msb = self._read_reg(REG_T1_T0_MSB)
 
-        t0_degC_x8 = ((t1_t0_msb & 0x03) << 8) | t0_degC_x8_lsb
-        t1_degC_x8 = ((t1_t0_msb & 0x0C) << 6) | t1_degC_x8_lsb
+        t0_degc_x8 = ((t1_t0_msb & 0x03) << 8) | t0_degc_x8_lsb
+        t1_degc_x8 = ((t1_t0_msb & 0x0C) << 6) | t1_degc_x8_lsb
 
         self._calibration = {
             "H0_rH": h0_rh_x2 / 2.0,
             "H1_rH": h1_rh_x2 / 2.0,
             "H0_T0_OUT": self._read_s16_le(REG_H0_T0_OUT_L),
             "H1_T0_OUT": self._read_s16_le(REG_H1_T0_OUT_L),
-            "T0_degC": t0_degC_x8 / 8.0,
-            "T1_degC": t1_degC_x8 / 8.0,
+            "T0_degC": t0_degc_x8 / 8.0,
+            "T1_degC": t1_degc_x8 / 8.0,
             "T0_OUT": self._read_s16_le(REG_T0_OUT_L),
             "T1_OUT": self._read_s16_le(REG_T1_OUT_L),
         }
@@ -250,8 +250,8 @@ class WSEN_HIDS(object):
         return self._clamp(humidity, 0.0, 100.0)
 
     def _convert_temperature(self, t_raw):
-        t0_degC = self._calibration["T0_degC"]
-        t1_degC = self._calibration["T1_degC"]
+        t0_degc = self._calibration["T0_degC"]
+        t1_degc = self._calibration["T1_degC"]
         t0_out = self._calibration["T0_OUT"]
         t1_out = self._calibration["T1_OUT"]
 
@@ -259,7 +259,7 @@ class WSEN_HIDS(object):
         if delta_out == 0:
             raise WSENHIDSError("Invalid temperature calibration data")
 
-        factory = ((t1_degC - t0_degC) * (t_raw - t0_out) / delta_out) + t0_degC
+        factory = ((t1_degc - t0_degc) * (t_raw - t0_out) / delta_out) + t0_degc
         return self._temp_gain * factory + self._temp_offset
 
     # -------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ select = [
   # "FBT",  # flake8-boolean-trap
   # "I",    # isort
   # "INP",  # flake8-no-pep420
-  # "N",    # pep8-naming
+  "N802",  # pep8-naming: function name should be lowercase
+  "N803",  # pep8-naming: argument name should be lowercase
+  "N806",  # pep8-naming: variable in function should be lowercase
+  "T20",   # flake8-print: no print() in production code
   # "NPY",  # NumPy-specific rules
   # "PD",   # pandas-vet
   # "PT",   # flake8-pytest-style
@@ -92,6 +95,8 @@ max-statements = 166
 [tool.ruff.lint.per-file-ignores]
 # manifest.py files are evaluated with some global names pre-defined
 "**/manifest.py" = ["F821"]
+"**/examples/*.py" = ["T20", "N806"]
+"tests/**/*.py" = ["T20"]
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.


### PR DESCRIPTION
Closes #135

## Summary

Enable 4 ruff naming rules to prevent camelCase regressions and enforce project conventions:

| Rule | Description |
|------|-------------|
| **N802** | Function name should be lowercase |
| **N803** | Argument name should be lowercase |
| **N806** | Variable in function should be lowercase |
| **T20** | No `print()` in production code (examples excluded) |

### Fixes to pass the new rules

| File | Fix |
|------|-----|
| `pyproject.toml` | Add N802, N803, N806, T20 to `select`; exclude examples from T20+N806 |
| `lib/lis2mdl/device.py` | `uT`→`mag_ut`, `T`→`temp`, `NORMALIZATION_THRESHOLD`→`norm_threshold`, `Xh`/`Yh`→`xh`/`yh`; `# noqa: N802` on `read_magnet_uT()`/`magnitude_uT()` |
| `lib/wsen-hids/device.py` | `t0_degC`→`t0_degc`, `t1_degC`→`t1_degc` (local variables only, dict keys unchanged) |
| `lib/hts221/device.py` | `lowerByte`→`lo`, `higherByte`→`hi` |
| `lib/bq27441/device.py` | `# noqa: N803` on `capacity_mAh` parameter |
| `lib/ssd1327/examples/rotating_3d_cube.py` | `drawCube()`→`draw_cube()` |

## Test plan

```bash
ruff check lib/                          # All checks passed
python3 -m pytest tests/ -k "mock" -v    # 99 passed
```