### PR TITLE
bq27441: Add reset() method for hardware reset.

### DIFF
--- a/lib/bq27441/bq27441/device.py
+++ b/lib/bq27441/bq27441/device.py
@@ -454,7 +454,11 @@ class BQ27441(object):
         # OpConfig register location: BQ27441_ID_REGISTERS id, offset 0
         return self.write_extended_data(BQ27441_ID_REGISTERS, 0, op_config_data, 2)
 
-    # Issue a soft - reset to the BQ27441 - G1A
+    # Full reset of the BQ27441-G1A
+    def reset(self):
+        return self.execute_control_word(BQ27441_CONTROL_RESET)
+
+    # Soft reset (resimulation) of the BQ27441-G1A
     def soft_reset(self):
         return self.execute_control_word(BQ27441_CONTROL_SOFT_RESET)
 

--- a/tests/scenarios/bq27441.yaml
+++ b/tests/scenarios/bq27441.yaml
@@ -67,6 +67,17 @@ tests:
     expect: 185
     mode: [mock]
 
+  - name: "Reset sends CONTROL_RESET command"
+    action: script
+    script: |
+      i2c.clear_write_log()
+      dev.reset()
+      log = i2c.get_write_log()
+      wrote_reset = any(reg == 0x00 and data[0] == 0x41 for reg, data in log)
+      result = wrote_reset
+    expect_true: true
+    mode: [mock]
+
   - name: "Read state of health"
     action: call
     method: state_of_health


### PR DESCRIPTION
Closes #145
Sub-PR of #143

## Summary

Add `reset()` method to the BQ27441 driver using `BQ27441_CONTROL_RESET` (0x0041). This performs a full hardware reset, distinct from the existing `soft_reset()` (0x0042) which only triggers a resimulation.

## Test plan

```bash
python3 -m pytest tests/ -k "bq27441 and mock" -v  # 8 passed
```

1 new mock test:
- Reset sends CONTROL_RESET command (verifies write of 0x41 to register 0x00)