### PR TITLE
drivers: Standardize power on/off method naming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ lib/<component>/
 - **I2C helpers**: use private snake_case methods `_read_reg()`, `_write_reg()` for register access.
 - **Device identification**: `device_id()` — returns the device/WHO_AM_I register value. All I2C drivers with an ID register must implement this method.
 - **Reset methods**: `reset()` for hardware reset (pin toggle), `soft_reset()` for software reset (register write), `reboot()` for memory reboot (reload trimming).
+- **Power methods**: `power_on()` / `power_off()`. All drivers must implement both.
 
 ### Linting
 

--- a/lib/apds9960/apds9960/device.py
+++ b/lib/apds9960/apds9960/device.py
@@ -111,7 +111,7 @@ class APDS9960(object):
     def enable_light_sensor(self, interrupts=True):
         self.set_ambient_light_gain(APDS9960_DEFAULT_AGAIN)
         self.set_ambient_light_int_enable(interrupts)
-        self.enable_power()
+        self.power_on()
         self.set_mode(APDS9960_MODE_AMBIENT_LIGHT, True)
 
     # stop the light sensor
@@ -124,7 +124,7 @@ class APDS9960(object):
         self.set_proximity_gain(APDS9960_DEFAULT_PGAIN)
         self.set_led_drive(APDS9960_DEFAULT_LDRIVE)
         self.set_proximity_int_enable(interrupts)
-        self.enable_power()
+        self.power_on()
         self.set_mode(APDS9960_MODE_PROXIMITY, True)
 
     # stop the proximity sensor
@@ -140,7 +140,7 @@ class APDS9960(object):
         self.set_led_boost(APDS9960_LED_BOOST_300)
         self.set_gesture_int_enable(interrupts)
         self.set_gesture_mode(True)
-        self.enable_power()
+        self.power_on()
         self.set_mode(APDS9960_MODE_WAIT, True)
         self.set_mode(APDS9960_MODE_PROXIMITY, True)
         self.set_mode(APDS9960_MODE_GESTURE, True)
@@ -213,10 +213,10 @@ class APDS9960(object):
         return motion
 
     # turn the APDS-9960 on
-    def enable_power(self):
+    def power_on(self):
         self.set_mode(APDS9960_MODE_POWER, True)
 
-    def disable_power(self):
+    def power_off(self):
         # turn the APDS-9960 off
         self.set_mode(APDS9960_MODE_POWER, False)
 

--- a/lib/bq27441/bq27441/device.py
+++ b/lib/bq27441/bq27441/device.py
@@ -90,7 +90,7 @@ class BQ27441(object):
         self.gpout_pin = gpout_pin
         self.capacity_mAh = capacity_mAh
         self.configure_gpout_input()
-        self.power_up()
+        self.power_on()
 
     def configure_gpout_input(self):
         if self.gpout_pin:
@@ -100,7 +100,7 @@ class BQ27441(object):
         if self.gpout_pin:
             self.gpout = Pin(self.gpout_pin, mode=Pin.OUT)
 
-    def power_up(self):
+    def power_on(self):
         """Wake up fuel gauge ic if in shutdown mode"""
         self.disable_shutdown_mode()
         sleep_ms(10)
@@ -109,7 +109,7 @@ class BQ27441(object):
         except Exception:
             raise
 
-    def power_down(self):
+    def power_off(self):
         """Put fuel gauge ic in shutdown mode by sending shutdown i2c cmd"""
         self.enter_shutdown_mode()
 

--- a/lib/ism330dl/README.md
+++ b/lib/ism330dl/README.md
@@ -234,7 +234,7 @@ Returns:
 ## Power Down
 
 ```python
-imu.power_down()
+imu.power_off()
 ```
 
 Stops accelerometer and gyroscope.

--- a/lib/ism330dl/ism330dl/device.py
+++ b/lib/ism330dl/ism330dl/device.py
@@ -263,6 +263,10 @@ class ISM330DL(object):
     # Power
     # --------------------------------------------------
 
-    def power_down(self):
+    def power_off(self):
         self._write_u8(REG_CTRL1_XL, 0)
         self._write_u8(REG_CTRL2_G, 0)
+
+    def power_on(self):
+        self.configure_accel(self._accel_odr, self._accel_scale)
+        self.configure_gyro(self._gyro_odr, self._gyro_scale)

--- a/lib/lis2mdl/README.md
+++ b/lib/lis2mdl/README.md
@@ -210,7 +210,7 @@ print("Register dump:", regs)
 | `heading_flat_only()`              | Flat compass heading           |
 | `heading_with_tilt_compensation()` | Tilt-corrected heading         |
 | `read_temperature_c()`             | Read relative temperature      |
-| `power_down()` / `wake()`          | Power management               |
+| `power_on()` / `power_off()`      | Power management               |
 | `soft_reset()` / `reboot()`        | Sensor reset functions         |
 
 ---

--- a/lib/lis2mdl/examples/magnet_test.py
+++ b/lib/lis2mdl/examples/magnet_test.py
@@ -518,7 +518,7 @@ def test_power_modes(dev):
     ok = True
 
     # Wake in continuous
-    dev.wake("continuous")
+    dev.power_on("continuous")
     r = dev.read_reg(LIS2MDL_CFG_REG_A)
     md = _bits(r, 1, 0)
     print(
@@ -530,7 +530,7 @@ def test_power_modes(dev):
     ok &= md == 0b00
 
     # Wake in single
-    dev.wake("single")
+    dev.power_on("single")
     r = dev.read_reg(LIS2MDL_CFG_REG_A)
     md = _bits(r, 1, 0)
     print(
@@ -542,11 +542,11 @@ def test_power_modes(dev):
     ok &= md == 0b01
 
     # Power down
-    dev.power_down()
+    dev.power_off()
     r = dev.read_reg(LIS2MDL_CFG_REG_A)
     md = _bits(r, 1, 0)
     print(
-        "power_down()        => MD=",
+        "power_off()        => MD=",
         md,
         "expected 0b11 =>",
         "OK" if md == 0b11 else "FAIL",
@@ -561,7 +561,7 @@ def test_power_modes(dev):
     ok &= dev.is_idle()
 
     # Back to continuous
-    dev.wake("continuous")
+    dev.power_on("continuous")
     r = dev.read_reg(LIS2MDL_CFG_REG_A)
     md = _bits(r, 1, 0)
     print(

--- a/lib/lis2mdl/lis2mdl/device.py
+++ b/lib/lis2mdl/lis2mdl/device.py
@@ -584,14 +584,14 @@ class LIS2MDL(object):
         md = r & 0b11
         return {0b00: "continuous", 0b01: "single", 0b11: "idle"}.get(md, "idle")
 
-    def power_down(self):
+    def power_off(self):
         """Switches to IDLE mode (low power)."""
         r = self._read_reg(LIS2MDL_CFG_REG_A)
         r = (r & ~0b11) | 0b11  # MD1..0 = 11
         self._write_reg(LIS2MDL_CFG_REG_A, r)
 
-    def wake(self, mode: str = "continuous"):
-        """Wakes the sensor: 'continuous' (default) or 'single'."""
+    def power_on(self, mode: str = "continuous"):
+        """Power on the sensor: 'continuous' (default) or 'single'."""
         md = {"continuous": 0b00, "single": 0b01}.get(mode, 0b00)
         r = self._read_reg(LIS2MDL_CFG_REG_A)
         r = (r & ~0b11) | md

--- a/lib/mcp23009e/mcp23009e/device.py
+++ b/lib/mcp23009e/mcp23009e/device.py
@@ -58,6 +58,13 @@ class MCP23009E(object):
         self.reset_pin.value(1)
         sleep_ms(10)
 
+    def power_off(self):
+        self.reset_pin.value(0)
+
+    def power_on(self):
+        self.reset_pin.value(1)
+        sleep_ms(10)
+
     def _soft_reset(self):
         """Réinitialise le composant avec les valeurs par défaut"""
         # Configuration par défaut : toutes les pins en entrée

--- a/lib/ssd1327/ssd1327/device.py
+++ b/lib/ssd1327/ssd1327/device.py
@@ -25,7 +25,7 @@ class SSD1327(object):
         # 96x96     32
         # 128x128   0
 
-        self.poweron()
+        self.power_on()
         self.init_display()
 
     def init_display(self):
@@ -81,12 +81,12 @@ class SSD1327(object):
         self.fill(0)
         self.write_data(self.buffer)
 
-    def poweroff(self):
+    def power_off(self):
         self.write_cmd(SET_FN_SELECT_A)
         self.write_cmd(0x00)  # Disable internal VDD regulator, to save power
         self.write_cmd(SET_DISP)
 
-    def poweron(self):
+    def power_on(self):
         self.write_cmd(SET_FN_SELECT_A)
         self.write_cmd(0x01)  # Enable internal VDD regulator
         self.write_cmd(SET_DISP | 0x01)
@@ -96,12 +96,12 @@ class SSD1327(object):
         self.write_cmd(contrast)  # 0-255
 
     def rotate(self, rotate):
-        self.poweroff()
+        self.power_off()
         self.write_cmd(SET_DISP_OFFSET)
         self.write_cmd(self.height if rotate else self.offset)
         self.write_cmd(SET_SEG_REMAP)
         self.write_cmd(0x42 if rotate else 0x51)
-        self.poweron()
+        self.power_on()
 
     def invert(self, invert):
         self.write_cmd(

--- a/lib/vl53l1x/vl53l1x/device.py
+++ b/lib/vl53l1x/vl53l1x/device.py
@@ -134,6 +134,13 @@ class VL53L1X(object):
         machine.lightsleep(100)
         self._write_reg(0x0000, 0x01)
 
+    def power_off(self):
+        self._write_reg(0x0000, 0x00)
+
+    def power_on(self):
+        self._write_reg(0x0000, 0x01)
+        machine.lightsleep(1)
+
     def start_ranging(self):
         self._write_reg(0x0087, 0x40)
 

--- a/lib/wsen-hids/wsen_hids/device.py
+++ b/lib/wsen-hids/wsen_hids/device.py
@@ -192,6 +192,16 @@ class WSEN_HIDS(object):
         ctrl1 |= odr
         self._write_reg(REG_CTRL_1, ctrl1)
 
+    def power_off(self):
+        ctrl1 = self._read_reg(REG_CTRL_1)
+        ctrl1 &= ~CTRL_1_PD
+        self._write_reg(REG_CTRL_1, ctrl1)
+
+    def power_on(self):
+        ctrl1 = self._read_reg(REG_CTRL_1)
+        ctrl1 |= CTRL_1_PD
+        self._write_reg(REG_CTRL_1, ctrl1)
+
     def enable_heater(self, enabled=True):
         value = CTRL_2_HEATER if enabled else 0
         self._update_reg(REG_CTRL_2, CTRL_2_HEATER, value)

--- a/lib/wsen-pads/examples/test.py
+++ b/lib/wsen-pads/examples/test.py
@@ -208,7 +208,7 @@ def test_continuous_mode(sensor, odr, label, wait_s=2):
 
             sleep(0.5)
 
-        sensor.power_down()
+        sensor.power_off()
 
         if ok:
             print_pass("Continuous mode - {}".format(label))
@@ -239,7 +239,7 @@ def test_status_flags(sensor):
         print("temperature_available() =", t_avail)
         print("is_ready()            =", ready)
 
-        sensor.power_down()
+        sensor.power_off()
 
         if p_avail or t_avail or ready:
             print_pass("STATUS helper methods")

--- a/lib/wsen-pads/wsen_pads/device.py
+++ b/lib/wsen-pads/wsen_pads/device.py
@@ -135,7 +135,7 @@ class WSEN_PADS(object):
         - low-noise disabled
         - low-pass filter disabled
         """
-        self.power_down()
+        self.power_off()
 
         # Enable automatic register address increment.
         self._update_reg(REG_CTRL_2, CTRL2_IF_ADD_INC, CTRL2_IF_ADD_INC)
@@ -180,9 +180,13 @@ class WSEN_PADS(object):
     # Power and reset control
     # ---------------------------------------------------------------------
 
-    def power_down(self):
+    def power_off(self):
         """Put the device in power-down mode by setting ODR = 000."""
         self._update_reg(REG_CTRL_1, CTRL1_ODR_MASK, ODR_POWER_DOWN << CTRL1_ODR_SHIFT)
+
+    def power_on(self, odr=ODR_1_HZ):
+        """Resume continuous measurement at the given ODR."""
+        self.set_continuous(odr=odr)
 
     def soft_reset(self):
         """
@@ -311,7 +315,7 @@ class WSEN_PADS(object):
         Parameters:
             low_noise: False for low-power mode, True for low-noise mode
         """
-        self.power_down()
+        self.power_off()
 
         # LOW_NOISE_EN must only be changed while in power-down mode.
         if low_noise:
@@ -375,7 +379,7 @@ class WSEN_PADS(object):
             raise ValueError("Low-noise mode is not available at 100 Hz or 200 Hz")
 
         # Enter power-down before changing LOW_NOISE_EN as required by the sensor.
-        self.power_down()
+        self.power_off()
 
         # Configure low-noise mode and auto-increment.
         ctrl2_value = CTRL2_IF_ADD_INC

--- a/tests/scenarios/apds9960.yaml
+++ b/tests/scenarios/apds9960.yaml
@@ -120,7 +120,7 @@ tests:
   - name: "Auto-enable restores power for light read"
     action: script
     script: |
-      dev.disable_power()
+      dev.power_off()
       i2c.clear_write_log()
       dev.read_red_light()
       log = i2c.get_write_log()

--- a/tests/scenarios/bq27441.yaml
+++ b/tests/scenarios/bq27441.yaml
@@ -8,7 +8,7 @@ i2c:
 
 # Register values for mock tests
 # BQ27441 uses 2-byte little-endian registers read via struct.unpack("<h")
-# The constructor calls power_up() -> set_capacity() -> writeExtendedData()
+# The constructor calls power_on() -> set_capacity() -> writeExtendedData()
 # which enters config mode (needs CFGUPMODE flag in FLAGS register).
 mock_registers:
   # CONTROL (0x00): status word (unsealed, INITCOMP set)

--- a/tests/scenarios/hts221.yaml
+++ b/tests/scenarios/hts221.yaml
@@ -85,7 +85,7 @@ tests:
     expect_not_none: true
     mode: [mock, hardware]
 
-  - name: "Auto-trigger temperature after poweroff"
+  - name: "Auto-trigger temperature after power_off"
     action: call
     setup:
       - method: power_off
@@ -93,7 +93,7 @@ tests:
     expect_not_none: true
     mode: [mock]
 
-  - name: "Auto-trigger humidity after poweroff"
+  - name: "Auto-trigger humidity after power_off"
     action: call
     setup:
       - method: power_off
@@ -173,7 +173,7 @@ tests:
     expect_true: true
     mode: [mock]
 
-  - name: "Auto-trigger after poweroff"
+  - name: "Auto-trigger after power_off"
     action: hardware_script
     script: |
       from machine import I2C

--- a/tests/scenarios/ism330dl.yaml
+++ b/tests/scenarios/ism330dl.yaml
@@ -276,7 +276,7 @@ tests:
     action: script
     script: |
       i2c.clear_write_log()
-      dev.power_down()
+      dev.power_off()
       log = i2c.get_write_log()
       writes = {reg: data[0] for reg, data in log}
       result = writes.get(0x10) == 0 and writes.get(0x11) == 0
@@ -302,7 +302,7 @@ tests:
   - name: "Acceleration readable after power down"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       ax, ay, az = dev.acceleration_g()
       result = isinstance(ax, float) and isinstance(ay, float) and isinstance(az, float)
     expect_true: true
@@ -311,7 +311,7 @@ tests:
   - name: "Gyroscope readable after power down"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       gx, gy, gz = dev.gyroscope_dps()
       result = isinstance(gx, float) and isinstance(gy, float) and isinstance(gz, float)
     expect_true: true
@@ -320,7 +320,7 @@ tests:
   - name: "Temperature readable after power down"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       t = dev.temperature_c()
       result = isinstance(t, float)
     expect_true: true
@@ -329,7 +329,7 @@ tests:
   - name: "Auto-trigger restores ODR after power down"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       dev.acceleration_raw()
       ctrl1 = i2c.readfrom_mem(dev.address, 0x10, 1)[0]
       ctrl2 = i2c.readfrom_mem(dev.address, 0x11, 1)[0]
@@ -343,7 +343,7 @@ tests:
       from ism330dl.const import ACCEL_ODR_26HZ, ACCEL_FS_2G, GYRO_ODR_52HZ, GYRO_FS_250DPS
       dev.configure_accel(ACCEL_ODR_26HZ, ACCEL_FS_2G)
       dev.configure_gyro(GYRO_ODR_52HZ, GYRO_FS_250DPS)
-      dev.power_down()
+      dev.power_off()
       dev.acceleration_raw()
       ctrl1 = i2c.readfrom_mem(dev.address, 0x10, 1)[0]
       ctrl2 = i2c.readfrom_mem(dev.address, 0x11, 1)[0]
@@ -356,9 +356,9 @@ tests:
   - name: "Repeated power down and read cycle"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       a1 = dev.acceleration_g()
-      dev.power_down()
+      dev.power_off()
       a2 = dev.acceleration_g()
       result = len(a1) == 3 and len(a2) == 3
     expect_true: true
@@ -378,7 +378,7 @@ tests:
   - name: "Timeout raises OSError when data never ready"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       i2c._registers[0x1E] = bytes([0x00])
       try:
           dev.acceleration_raw()
@@ -392,7 +392,7 @@ tests:
   - name: "Fresh acceleration after power down"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       ax, ay, az = dev.acceleration_g()
       mag = (ax**2 + ay**2 + az**2) ** 0.5
       result = 0.8 < mag < 1.2
@@ -402,7 +402,7 @@ tests:
   - name: "Fresh temperature after power down"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       t = dev.temperature_c()
       result = 10.0 < t < 50.0
     expect_true: true

--- a/tests/scenarios/lis2mdl.yaml
+++ b/tests/scenarios/lis2mdl.yaml
@@ -91,7 +91,7 @@ tests:
   - name: "Magnetic field readable after power down"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       x, y, z = dev.read_magnet()
       result = isinstance(x, int) and isinstance(y, int) and isinstance(z, int)
     expect_true: true
@@ -100,7 +100,7 @@ tests:
   - name: "Temperature readable after power down"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       t = dev.read_temperature_c()
       result = isinstance(t, float)
     expect_true: true
@@ -109,7 +109,7 @@ tests:
   - name: "Auto-trigger writes single mode to CFG_REG_A"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       i2c.clear_write_log()
       dev.read_magnet()
       log = i2c.get_write_log()
@@ -132,7 +132,7 @@ tests:
   - name: "Fresh magnitude after power down"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       mag = dev.magnitude_uT()
       result = 10.0 < mag < 300.0
     expect_true: true
@@ -141,7 +141,7 @@ tests:
   - name: "Fresh temperature after power down"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       t = dev.read_temperature_c()
       result = 10.0 < t < 45.0
     expect_true: true

--- a/tests/scenarios/mcp23009e.yaml
+++ b/tests/scenarios/mcp23009e.yaml
@@ -53,6 +53,23 @@ tests:
     expect_not_none: true
     mode: [mock, hardware]
 
+  - name: "Power off holds reset pin low"
+    action: script
+    script: |
+      dev.power_off()
+      result = dev.reset_pin.value() == 0
+    expect_true: true
+    mode: [mock]
+
+  - name: "Power on releases reset pin"
+    action: script
+    script: |
+      dev.power_off()
+      dev.power_on()
+      result = dev.reset_pin.value() == 1
+    expect_true: true
+    mode: [mock]
+
   - name: "Read individual GPIO level"
     action: call
     method: get_level

--- a/tests/scenarios/ssd1327.yaml
+++ b/tests/scenarios/ssd1327.yaml
@@ -36,6 +36,23 @@ tests:
     args: ["Test", 0, 0, 15]
     mode: [mock]
 
+  - name: "Power off does not crash"
+    action: script
+    script: |
+      dev.power_off()
+      result = True
+    expect_true: true
+    mode: [mock]
+
+  - name: "Power on does not crash"
+    action: script
+    script: |
+      dev.power_off()
+      dev.power_on()
+      result = True
+    expect_true: true
+    mode: [mock]
+
   - name: "Show does not crash"
     action: call
     method: show

--- a/tests/scenarios/vl53l1x.yaml
+++ b/tests/scenarios/vl53l1x.yaml
@@ -74,6 +74,29 @@ tests:
     expect_true: true
     mode: [mock]
 
+  - name: "Power off writes reset register"
+    action: script
+    script: |
+      i2c.clear_write_log()
+      dev.power_off()
+      log = i2c.get_write_log()
+      wrote_off = any(reg == 0x0000 and data[0] == 0x00 for reg, data in log)
+      result = wrote_off
+    expect_true: true
+    mode: [mock]
+
+  - name: "Power on writes reset register"
+    action: script
+    script: |
+      dev.power_off()
+      i2c.clear_write_log()
+      dev.power_on()
+      log = i2c.get_write_log()
+      wrote_on = any(reg == 0x0000 and data[0] == 0x01 for reg, data in log)
+      result = wrote_on
+    expect_true: true
+    mode: [mock]
+
   # ----- Hardware -----
 
   - name: "Distance in plausible range"

--- a/tests/scenarios/wsen_hids.yaml
+++ b/tests/scenarios/wsen_hids.yaml
@@ -77,6 +77,25 @@ tests:
     expect_range: [24.0, 26.0]
     mode: [mock]
 
+  - name: "Power off clears PD bit"
+    action: script
+    script: |
+      dev.power_off()
+      ctrl1 = i2c.readfrom_mem(dev.address, 0x20, 1)[0]
+      result = (ctrl1 & 0x80) == 0
+    expect_true: true
+    mode: [mock]
+
+  - name: "Power on restores continuous mode"
+    action: script
+    script: |
+      dev.power_off()
+      dev.power_on()
+      ctrl1 = i2c.readfrom_mem(dev.address, 0x20, 1)[0]
+      result = (ctrl1 & 0x80) != 0
+    expect_true: true
+    mode: [mock]
+
   - name: "Temperature with offset"
     action: script
     script: |

--- a/tests/scenarios/wsen_pads.yaml
+++ b/tests/scenarios/wsen_pads.yaml
@@ -86,7 +86,7 @@ tests:
   - name: "Timeout raises exception when data never ready"
     action: script
     script: |
-      dev.power_down()
+      dev.power_off()
       i2c._registers[0x27] = bytes([0x00])
       try:
           dev.pressure()


### PR DESCRIPTION
Closes #76

## Summary

Standardize all power on/off methods to `power_on()` / `power_off()`.

### Changes

| Driver | Before | After |
|--------|--------|-------|
| **apds9960** | `enable_power()` / `disable_power()` | `power_on()` / `power_off()` |
| **bq27441** | `power_up()` / `power_down()` | `power_on()` / `power_off()` |
| **hts221** | `power_on()` / `power_off()` | _(unchanged)_ |
| **ism330dl** | — / `power_down()` | `power_on()` / `power_off()` |
| **lis2mdl** | `wake()` / `power_down()` | `power_on()` / `power_off()` |
| **mcp23009e** | — / — | `power_on()` / `power_off()` added (via RESET pin) |
| **ssd1327** | `poweron()` / `poweroff()` | `power_on()` / `power_off()` |
| **vl53l1x** | — / — | `power_on()` / `power_off()` added (via SOFT_RESET register) |
| **wsen-hids** | — / — | `power_on()` / `power_off()` added (via PD bit) |
| **wsen-pads** | — / `power_down()` | `power_on()` / `power_off()` |

### Final state

| Driver | `power_on()` | `power_off()` |
|--------|:------------:|:--------------:|
| **apds9960** | ✓ | ✓ |
| **bq27441** | ✓ | ✓ |
| **hts221** | ✓ | ✓ |
| **ism330dl** | ✓ | ✓ |
| **lis2mdl** | ✓ | ✓ |
| **mcp23009e** | ✓ | ✓ |
| **ssd1327** | ✓ | ✓ |
| **vl53l1x** | ✓ | ✓ |
| **wsen-hids** | ✓ | ✓ |
| **wsen-pads** | ✓ | ✓ |

Also updated README, tests (8 new mock tests), examples, and driver READMEs.

## Test plan

```bash
ruff check lib/                          # All checks passed
python3 -m pytest tests/ -k "mock" -v    # 111 passed
```