### PR TITLE
drivers: Make status() private across all sensor drivers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ lib/<component>/
 - **Device identification**: `device_id()` — returns the device/WHO_AM_I register value. All I2C drivers with an ID register must implement this method.
 - **Reset methods**: `reset()` for hardware reset (pin toggle), `soft_reset()` for software reset (register write), `reboot()` for memory reboot (reload trimming).
 - **Power methods**: `power_on()` / `power_off()`. All drivers must implement both.
-- **Status methods**: `status()` returns the raw status register as an int, `data_ready()` returns True when all channels have new data, `<measurement>_ready()` for per-channel readiness (e.g. `temperature_ready()`, `pressure_ready()`).
+- **Status methods**: `_status()` returns the raw status register as an int (private), `data_ready()` returns True when all channels have new data, `<measurement>_ready()` for per-channel readiness (e.g. `temperature_ready()`, `pressure_ready()`).
 
 ### Linting
 

--- a/lib/apds9960/apds9960/device.py
+++ b/lib/apds9960/apds9960/device.py
@@ -82,7 +82,7 @@ class APDS9960(object):
     def device_id(self):
         return self.dev_id
 
-    def status(self):
+    def _status(self):
         return self._read_reg(APDS9960_REG_STATUS)
 
     def data_ready(self):
@@ -230,18 +230,11 @@ class APDS9960(object):
     # ambient light and color sensor controls
     # *******************************************************************************
 
-    # check if there is new light data available
     def light_ready(self):
-        val = self._read_reg(APDS9960_REG_STATUS)
-
-        # mask out AVALID bit
-        val &= APDS9960_BIT_AVALID
-
-        return val == APDS9960_BIT_AVALID
+        return bool(self._status() & APDS9960_BIT_AVALID)
 
     def proximity_ready(self):
-        val = self._read_reg(APDS9960_REG_STATUS)
-        return (val & APDS9960_BIT_PVALID) == APDS9960_BIT_PVALID
+        return bool(self._status() & APDS9960_BIT_PVALID)
 
     def _ensure_light_enabled(self):
         enable = self.get_mode()

--- a/lib/hts221/hts221/device.py
+++ b/lib/hts221/hts221/device.py
@@ -61,18 +61,18 @@ class HTS221(object):
         return self._read_reg(HTS221_WHO_AM_I)
 
     # get STATUS register
-    def status(self):
+    def _status(self):
         return self._read_reg(HTS221_STATUS_REG)
 
     def data_ready(self):
-        s = self.status()
+        s = self._status()
         return bool((s & HTS221_STATUS_T_DA) and (s & HTS221_STATUS_H_DA))
 
     def temperature_ready(self):
-        return bool(self.status() & HTS221_STATUS_T_DA)
+        return bool(self._status() & HTS221_STATUS_T_DA)
 
     def humidity_ready(self):
-        return bool(self.status() & HTS221_STATUS_H_DA)
+        return bool(self._status() & HTS221_STATUS_H_DA)
 
     # power control
     def power_off(self):

--- a/lib/ism330dl/ism330dl/device.py
+++ b/lib/ism330dl/ism330dl/device.py
@@ -251,20 +251,20 @@ class ISM330DL(object):
     # Status
     # --------------------------------------------------
 
-    def status(self):
+    def _status(self):
         return self._read_u8(REG_STATUS_REG)
 
     def accel_ready(self):
-        return bool(self.status() & STATUS_XLDA)
+        return bool(self._status() & STATUS_XLDA)
 
     def gyro_ready(self):
-        return bool(self.status() & STATUS_GDA)
+        return bool(self._status() & STATUS_GDA)
 
     def temperature_ready(self):
-        return bool(self.status() & STATUS_TDA)
+        return bool(self._status() & STATUS_TDA)
 
     def data_ready(self):
-        s = self._read_u8(REG_STATUS_REG)
+        s = self._status()
         return bool((s & STATUS_XLDA) and (s & STATUS_GDA) and (s & STATUS_TDA))
 
     # --------------------------------------------------

--- a/lib/lis2mdl/examples/magnet_test.py
+++ b/lib/lis2mdl/examples/magnet_test.py
@@ -239,7 +239,7 @@ def test_reads(dev):
     ok &= who == 0x40
 
     # STATUS & DATA READY
-    st1 = dev.status()
+    st1 = dev.data_ready()
     print(f"Initial STATUS=0x{st1:02X}")
     # wait a few ms to let a new frame arrive
     sleep_ms(50)

--- a/lib/lis2mdl/lis2mdl/device.py
+++ b/lib/lis2mdl/lis2mdl/device.py
@@ -182,13 +182,13 @@ class LIS2MDL(object):
         """Reads the raw magnetic field (LSB). Same as read_magnet(), but more explicit."""
         return self.read_magnet()  # (x,y,z) int16 LSB
 
-    def status(self) -> int:
+    def _status(self) -> int:
         """Reads STATUS_REG (0x67)."""
         return self._read_reg(LIS2MDL_STATUS_REG)
 
     def data_ready(self) -> bool:
         """True if a new XYZ triplet is ready (Zyxda bit)."""
-        return bool(self.status() & (1 << 3))
+        return bool(self._status() & (1 << 3))
 
     def read_int_source(self) -> int:
         """Reads INT_SOURCE_REG (0x64): source of the interrupt."""
@@ -331,7 +331,7 @@ class LIS2MDL(object):
         mag_ut = self.read_magnet_uT()
         cal = self.read_magnet_calibrated_norm()
         temp = self.read_temperature_c()
-        st = self.status()
+        st = self._status()
         return {"raw": raw, "uT": mag_ut, "cal_norm": cal, "tempC": temp, "status": st}
 
     ##

--- a/lib/wsen-hids/examples/full_test.py
+++ b/lib/wsen-hids/examples/full_test.py
@@ -143,7 +143,7 @@ def test_one_shot(sensor):
     try:
         humidity_rh, temperature_c = sensor.read_one_shot(timeout_ms=500)
 
-        status = sensor.status()
+        status = sensor.data_ready()
         h_ready = sensor.humidity_ready()
         t_ready = sensor.temperature_ready()
         ready = sensor.data_ready()
@@ -241,7 +241,7 @@ def test_continuous_mode(sensor, odr, label, wait_ms=1500, loops=5, delay_s=0.5)
 
         for i in range(loops):
             humidity_rh, temperature_c = sensor.read()
-            status = sensor.status()
+            status = sensor.data_ready()
 
             print(
                 "#{:d}  H={:.2f} %RH  T={:.2f} °C  STATUS=0x{:02X}".format(
@@ -290,7 +290,7 @@ def test_status_helpers(sensor):
         sensor.set_continuous_mode(odr=ODR_1_HZ)
         sleep(1.5)
 
-        status = sensor.status()
+        status = sensor.data_ready()
         h_avail = sensor.humidity_ready()
         t_avail = sensor.temperature_ready()
         ready = sensor.data_ready()

--- a/lib/wsen-hids/wsen_hids/device.py
+++ b/lib/wsen-hids/wsen_hids/device.py
@@ -215,17 +215,17 @@ class WSEN_HIDS(object):
     # Status
     # -------------------------------------------------------------------------
 
-    def status(self):
+    def _status(self):
         return self._read_reg(REG_STATUS)
 
     def humidity_ready(self):
-        return bool(self.status() & STATUS_H_DA)
+        return bool(self._status() & STATUS_H_DA)
 
     def temperature_ready(self):
-        return bool(self.status() & STATUS_T_DA)
+        return bool(self._status() & STATUS_T_DA)
 
     def data_ready(self):
-        status = self.status()
+        status = self._status()
         return bool((status & STATUS_H_DA) and (status & STATUS_T_DA))
 
     # -------------------------------------------------------------------------

--- a/lib/wsen-pads/examples/test.py
+++ b/lib/wsen-pads/examples/test.py
@@ -31,12 +31,11 @@ def print_fail(name, err=None):
 def dump_registers(sensor):
     ctrl1 = sensor._read_u8(REG_CTRL_1)
     ctrl2 = sensor._read_u8(REG_CTRL_2)
-    status = sensor._read_u8(REG_STATUS)
     int_source = sensor._read_u8(REG_INT_SOURCE)
 
     print("CTRL_1     = 0x{:02X}".format(ctrl1))
     print("CTRL_2     = 0x{:02X}".format(ctrl2))
-    print("STATUS     = 0x{:02X}".format(status))
+    print("data_ready() =", sensor.data_ready())
     print("INT_SOURCE = 0x{:02X}".format(int_source))
 
 
@@ -136,13 +135,12 @@ def test_one_shot(sensor):
 
         raw_p = sensor.pressure_raw()
         raw_t = sensor.temperature_raw()
-        status = sensor.status()
 
         print("Raw pressure    :", raw_p)
         print("Raw temperature :", raw_t)
         print("Pressure        : {:.2f} hPa".format(pressure_hpa))
         print("Temperature     : {:.2f} °C".format(temperature_c))
-        print("STATUS          : 0x{:02X}".format(status))
+        print("data_ready()    :", sensor.data_ready())
 
         # Basic sanity checks
         MIN_PRESSURE = 260.0
@@ -190,16 +188,14 @@ def test_continuous_mode(sensor, odr, label, wait_s=2):
             temperature_c = sensor.temperature()
             raw_p = sensor.pressure_raw()
             raw_t = sensor.temperature_raw()
-            status = sensor.status()
-
             print(
-                "#{:d}  P={:.2f} hPa  T={:.2f} °C  rawP={}  rawT={}  STATUS=0x{:02X}".format(
+                "#{:d}  P={:.2f} hPa  T={:.2f} °C  rawP={}  rawT={}  ready={}".format(
                     i + 1,
                     pressure_hpa,
                     temperature_c,
                     raw_p,
                     raw_t,
-                    status,
+                    sensor.data_ready(),
                 )
             )
 
@@ -229,12 +225,10 @@ def test_status_flags(sensor):
         sensor.set_continuous(odr=ODR_1_HZ)
         sleep(1.5)
 
-        status = sensor.status()
         p_avail = sensor.pressure_ready()
         t_avail = sensor.temperature_ready()
         ready = sensor.data_ready()
 
-        print("STATUS                = 0x{:02X}".format(status))
         print("pressure_ready()      =", p_avail)
         print("temperature_ready()   =", t_avail)
         print("data_ready()          =", ready)

--- a/lib/wsen-pads/wsen_pads/device.py
+++ b/lib/wsen-pads/wsen_pads/device.py
@@ -155,17 +155,17 @@ class WSEN_PADS(object):
         """Return the value of the DEVICE_ID register."""
         return self._read_reg(REG_DEVICE_ID)
 
-    def status(self):
+    def _status(self):
         """Return the raw STATUS register value."""
         return self._read_reg(REG_STATUS)
 
     def pressure_ready(self):
         """Return True when new pressure data is available."""
-        return bool(self.status() & STATUS_P_DA)
+        return bool(self._status() & STATUS_P_DA)
 
     def temperature_ready(self):
         """Return True when new temperature data is available."""
-        return bool(self.status() & STATUS_T_DA)
+        return bool(self._status() & STATUS_T_DA)
 
     def data_ready(self):
         """
@@ -173,7 +173,7 @@ class WSEN_PADS(object):
 
         This is mainly useful in continuous mode.
         """
-        status = self.status()
+        status = self._status()
         return bool((status & STATUS_P_DA) and (status & STATUS_T_DA))
 
     # ---------------------------------------------------------------------

--- a/tests/scenarios/hts221.yaml
+++ b/tests/scenarios/hts221.yaml
@@ -82,7 +82,7 @@ tests:
   - name: "Status register returns int"
     action: script
     script: |
-      result = isinstance(dev.status(), int)
+      result = isinstance(dev._status(), int)
     expect_true: true
     mode: [mock]
 

--- a/tests/scenarios/ism330dl.yaml
+++ b/tests/scenarios/ism330dl.yaml
@@ -45,7 +45,7 @@ tests:
   - name: "Status returns raw register value"
     action: script
     script: |
-      result = isinstance(dev.status(), int)
+      result = isinstance(dev._status(), int)
     expect_true: true
     mode: [mock]
 

--- a/tests/scenarios/lis2mdl.yaml
+++ b/tests/scenarios/lis2mdl.yaml
@@ -48,7 +48,7 @@ tests:
 
   - name: "Read status register"
     action: call
-    method: status
+    method: _status
     expect_not_none: true
     mode: [mock, hardware]
 

--- a/tests/scenarios/wsen_hids.yaml
+++ b/tests/scenarios/wsen_hids.yaml
@@ -61,7 +61,7 @@ tests:
 
   - name: "Read status register"
     action: call
-    method: status
+    method: _status
     expect_not_none: true
     mode: [mock, hardware]
 

--- a/tests/scenarios/wsen_pads.yaml
+++ b/tests/scenarios/wsen_pads.yaml
@@ -42,7 +42,7 @@ tests:
 
   - name: "Read status register"
     action: call
-    method: status
+    method: _status
     expect_not_none: true
     mode: [mock, hardware]
 


### PR DESCRIPTION
Closes #150, #151, #152, #153, #154, #155

## Summary

Rename `status()` → `_status()` in 6 sensor drivers. The raw status register is an implementation detail — users should use `data_ready()` and `*_ready()` methods instead.

| Driver | Change |
|--------|--------|
| **hts221** | `status()` → `_status()` |
| **ism330dl** | `status()` → `_status()` |
| **lis2mdl** | `status()` → `_status()` |
| **wsen-hids** | `status()` → `_status()` |
| **wsen-pads** | `status()` → `_status()` |
| **apds9960** | `status()` → `_status()` |

BQ27441 `status()` handled separately in #156 (different semantics).

Also updated all internal callers, tests, examples, and README.

## Test plan

```bash
ruff check lib/                          # All checks passed
python3 -m pytest tests/ -k "mock" -v    # 111 passed
```