### PR TITLE
bq27441: Rename status() to _control_status().

### DIFF
--- a/lib/bq27441/bq27441/device.py
+++ b/lib/bq27441/bq27441/device.py
@@ -419,13 +419,13 @@ class BQ27441(object):
         return self.read_word(BQ27441_COMMAND_FLAGS)
 
     # Read the CONTROL_STATUS subcommand of control()
-    def status(self):
+    def _control_status(self):
         return self.read_control_word(BQ27441_CONTROL_STATUS)
 
     # Private Functions
     # Check if the BQ27441 - G1A is sealed or not.
     def sealed(self):
-        stat = self.status()
+        stat = self._control_status()
         return stat & BQ27441_STATUS_SS
 
     # Seal the BQ27441 - G1A


### PR DESCRIPTION
Closes #156

## Summary

Rename `status()` → `_control_status()` in BQ27441 driver. Unlike sensor drivers where `status()` reads a data-ready register, the BQ27441 `status()` reads the CONTROL_STATUS word (sealed state, shutdown flags). The distinct name avoids confusion with the sensor `_status()` convention.

Only caller is `sealed()`, updated accordingly.

## Test plan

```bash
python3 -m pytest tests/ -k "bq27441 and mock" -v  # 8 passed
```