### PR TITLE
bq27441: Fix checksum overflow in compute_block_checksum().

### DIFF
--- a/lib/bq27441/bq27441/device.py
+++ b/lib/bq27441/bq27441/device.py
@@ -530,7 +530,7 @@ class BQ27441(object):
         for i in range(32):
             csum += data[i]
 
-        csum = 255 - csum
+        csum = (255 - (csum & 0xFF)) & 0xFF
         return csum
 
     # Use the block_data_checksum command to write a checksum value


### PR DESCRIPTION
Closes #162

## Summary

Fix a pre-existing bug where `compute_block_checksum()` could produce a negative value when the sum of the 32 data bytes exceeds 255. This caused `ValueError: bytes value out of range` in `_write_reg()` during `__init__` → `power_on()` → `set_capacity()` → `write_extended_data()`.

### Root cause

```python
csum = 255 - csum  # csum can be > 255, result is negative
```

### Fix

```python
csum = (255 - (csum & 0xFF)) & 0xFF  # mask to byte range
```

This bug has existed since the initial driver commit but only manifests on real hardware (mock I2C returns zeroed data that stays within range).

## Test plan

### Mock tests
```bash
python3 -m pytest tests/ -k "bq27441 and mock" -v  # 8 passed
```

### Hardware tests
```bash
python3 -m pytest tests/ --port /dev/ttyACM0 -k "bq27441 and hardware" -s -v  # 8 passed
```