### PR TITLE
tests: Make I2C scan pass without battery connected.

### DIFF
--- a/tests/scenarios/board_i2c_scan.yaml
+++ b/tests/scenarios/board_i2c_scan.yaml
@@ -15,9 +15,10 @@ tests:
       found = i2c.scan()
       # Expected I2C addresses on STeaMi board (7-bit):
       # 0x1E=LIS2MDL, 0x20=MCP23009E, 0x29=VL53L1X, 0x39=APDS9960
-      # 0x3B=STM32F103CB, 0x55=BQ27441, 0x5D=WSEN-PADS
+      # 0x3B=STM32F103CB, 0x5D=WSEN-PADS
       # 0x5F=HTS221/WSEN-HIDS, 0x6B=ISM330DL
-      expected = [0x1E, 0x20, 0x29, 0x39, 0x3B, 0x55, 0x5D, 0x5F, 0x6B]
+      # Note: 0x55=BQ27441 excluded (only present when battery connected)
+      expected = [0x1E, 0x20, 0x29, 0x39, 0x3B, 0x5D, 0x5F, 0x6B]
       missing = sorted([hex(a) for a in expected if a not in found])
       result = missing
     expect: []


### PR DESCRIPTION
## Summary
- Remove BQ27441 (0x55) from mandatory expected devices in I2C scan test
- The BQ27441 only responds when a battery is connected, so the scan should not require it
- BQ27441 remains in the `known` list so it is not flagged as unexpected when present

## Test plan
- [x] Run `pytest tests/ -v -k board_i2c_scan --port /dev/ttyACM0 -s` without battery → should pass
- [x] Run with battery → should also pass (BQ27441 not flagged as unexpected)