### PR TITLE
docs: Harmonize wsen-hids README — add I2C address and power sections.

### DIFF
--- a/lib/wsen-hids/README.md
+++ b/lib/wsen-hids/README.md
@@ -42,7 +42,7 @@ Main characteristics:
 # Quick Example
 
 ```python
-from machine import I2C, Pin
+from machine import I2C
 from time import sleep
 from wsen_hids import WSEN_HIDS
 


### PR DESCRIPTION
Closes #197
Parent issue: #194

Add missing README sections for WSEN-HIDS driver

This PR completes the documentation by adding:

I²C Address section (default: 0x5F)
Power Management section (power_off, power_on, reboot)
Also fixes minor formatting issues in the README.