### PR TITLE
ism330dl: Rename temperature_c() to temperature() for convention.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ imu = ISM330DL(i2c)
 # Reading values
 ax, ay, az = imu.acceleration_g()
 gx, gy, gz = imu.gyroscope_dps()
-temp = imu.temperature_c()
+temp = imu.temperature()
 
 # Configuration
 from ism330dl.const import ACCEL_ODR_104HZ, ACCEL_FS_4G

--- a/lib/ism330dl/README.md
+++ b/lib/ism330dl/README.md
@@ -62,7 +62,7 @@ imu = ISM330DL(i2c)
 
 ax, ay, az = imu.acceleration_g()
 gx, gy, gz = imu.gyroscope_dps()
-temp = imu.temperature_c()
+temp = imu.temperature()
 
 print("Accel:", ax, ay, az)
 print("Gyro :", gx, gy, gz)
@@ -168,7 +168,7 @@ imu.motion()
 ## Temperature
 
 ```python
-imu.temperature_c()
+imu.temperature()
 ```
 
 Example:

--- a/lib/ism330dl/examples/basic_read.py
+++ b/lib/ism330dl/examples/basic_read.py
@@ -13,7 +13,7 @@ while True:
 
     ax, ay, az = imu.acceleration_g()
     gx, gy, gz = imu.gyroscope_dps()
-    temp = imu.temperature_c()
+    temp = imu.temperature()
 
     print(
         "A[g]=({:+.2f},{:+.2f},{:+.2f})  "

--- a/lib/ism330dl/ism330dl/device.py
+++ b/lib/ism330dl/ism330dl/device.py
@@ -182,7 +182,7 @@ class ISM330DL(object):
         dps = self.gyroscope_dps()
         return tuple(v * pi / 180.0 for v in dps)
 
-    def temperature_c(self):
+    def temperature(self):
         factory = TEMP_OFFSET + self.temperature_raw() / TEMP_SENSITIVITY
         return self._temp_gain * factory + self._temp_offset
 

--- a/lib/steami_config/examples/calibrate_temperature.py
+++ b/lib/steami_config/examples/calibrate_temperature.py
@@ -32,7 +32,7 @@ SENSORS = [
     ("hts221", "hts221.device", "HTS221", "temperature"),
     ("wsen_pads", "wsen_pads.device", "WSEN_PADS", "temperature"),
     ("lis2mdl", "lis2mdl.device", "LIS2MDL", "temperature"),
-    ("ism330dl", "ism330dl.device", "ISM330DL", "temperature_c"),
+    ("ism330dl", "ism330dl.device", "ISM330DL", "temperature"),
 ]
 
 for config_name, module, class_name, method in SENSORS:

--- a/tests/scenarios/board_temperature_comparison.yaml
+++ b/tests/scenarios/board_temperature_comparison.yaml
@@ -58,7 +58,7 @@ tests:
       from ism330dl.device import ISM330DL
       imu = ISM330DL(i2c)
       sleep_ms(200)  # stabilize after reset
-      temps['ISM330DL'] = imu.temperature_c()
+      temps['ISM330DL'] = imu.temperature()
 
       # Print comparison table
       print('--- Temperature Comparison ---')
@@ -155,7 +155,7 @@ tests:
       mag_t = mag.temperature()
 
       ref_t4 = ref.temperature()
-      imu_t = imu.temperature_c()
+      imu_t = imu.temperature()
 
       print('--- Before offset alignment ---')
       print('  WSEN-HIDS (ref): ' + str(round(ref_t, 2)) + ' C')
@@ -179,7 +179,7 @@ tests:
       hts_t2 = hts.temperature()
       pads_t2 = pads.temperature()
       mag_t2 = mag.temperature()
-      imu_t2 = imu.temperature_c()
+      imu_t2 = imu.temperature()
 
       print('--- After offset alignment ---')
       print('  WSEN-HIDS (ref): ' + str(round(ref_t5, 2)) + ' C')

--- a/tests/scenarios/ism330dl.yaml
+++ b/tests/scenarios/ism330dl.yaml
@@ -141,7 +141,7 @@ tests:
 
   - name: "Temperature returns 25.0 from mock data"
     action: call
-    method: temperature_c
+    method: temperature
     expect_range: [24.9, 25.1]
     mode: [mock]
 
@@ -156,7 +156,7 @@ tests:
     action: script
     script: |
       dev.set_temp_offset(-2.5)
-      result = abs(dev.temperature_c() - 22.5) < 0.1
+      result = abs(dev.temperature() - 22.5) < 0.1
     expect_true: true
     mode: [mock]
 
@@ -164,7 +164,7 @@ tests:
     action: script
     script: |
       dev.calibrate_temperature(20.0, 25.0, 30.0, 35.0)
-      result = dev.temperature_c()
+      result = dev.temperature()
     expect_range: [19.0, 21.0]
     mode: [mock]
 
@@ -181,7 +181,7 @@ tests:
 
   - name: "Temperature in plausible range"
     action: call
-    method: temperature_c
+    method: temperature
     expect_range: [10.0, 50.0]
     mode: [hardware]
 
@@ -328,7 +328,7 @@ tests:
     action: script
     script: |
       dev.power_off()
-      t = dev.temperature_c()
+      t = dev.temperature()
       result = isinstance(t, float)
     expect_true: true
     mode: [mock]
@@ -410,7 +410,7 @@ tests:
     action: script
     script: |
       dev.power_off()
-      t = dev.temperature_c()
+      t = dev.temperature()
       result = 10.0 < t < 50.0
     expect_true: true
     mode: [hardware]
@@ -426,7 +426,7 @@ tests:
       - method: gyroscope_dps
         label: "Gyroscope (dps)"
         unit: ""
-      - method: temperature_c
+      - method: temperature
         label: "Temperature"
         unit: "°C"
       - method: orientation


### PR DESCRIPTION
Closes #210

## Summary

Rename `temperature_c()` to `temperature()` in the ISM330DL driver to follow the project convention: no unit suffix for SI units (°C for temperature, %RH for humidity).

## Changes

| File | Change |
|------|--------|
| `lib/ism330dl/ism330dl/device.py` | Method renamed |
| `lib/ism330dl/examples/basic_read.py` | Call updated |
| `lib/ism330dl/README.md` | API doc updated (2 occurrences) |
| `tests/scenarios/ism330dl.yaml` | 7 test references updated |
| `tests/scenarios/board_temperature_comparison.yaml` | 3 references updated |
| `lib/steami_config/examples/calibrate_temperature.py` | ISM330DL entry updated |
| `README.md` | Quick start example updated |

## Verification

- `ruff check` passes
- 34/34 ISM330DL mock tests pass
- No remaining `temperature_c` method calls (only local variable names in other drivers, which are unrelated)