### PR TITLE
ci: Replace regex commit checker with commitlint.

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -22,11 +22,11 @@ jobs:
       - name: "🟢 Set up Node.js"
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "20.17.x"
           cache: "npm"
 
       - name: "🛠 Install commitlint"
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: "📜 Validate commit messages"
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+        run: npx --no-install commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
## Summary

Closes #231.

Replaces the `gsactions/commit-message-checker` (regex-based) with commitlint in CI, so that local hooks and CI use the **same tool and same rules**.

### Before

- Local: commitlint via husky hook (conventional commits format)
- CI: regex `^[^!]+: [A-Za-z]+.+ .+\.$` via gsactions/commit-message-checker
- Mismatch: conventional commits (`feat(scope): ...`) accepted locally but rejected by CI regex

### After

- Local: commitlint via husky hook
- CI: commitlint via `npx commitlint --from base..head`
- Same `commitlint.config.js` used everywhere

### Changes

- `.github/workflows/check-commits.yml` — replaced gsactions with checkout + node + npm ci + commitlint
- `fetch-depth: 0` to access full commit history for range validation
- Uses `${{ github.event.pull_request.base.sha }}` and `head.sha` for precise commit range

## Test plan

- [x] `npx commitlint --from HEAD~3 --to HEAD --verbose` passes locally
- [x] CI workflow passes on this PR