### PR TITLE
fix(steami_config): Simplify calibrate_temperature for frozen drivers.

### DIFF
--- a/lib/steami_config/examples/calibrate_temperature.py
+++ b/lib/steami_config/examples/calibrate_temperature.py
@@ -40,7 +40,7 @@ sensors = [
 ]
 
 for name, sensor in sensors:
-    if name == "ism330dl":
+    if name in ("ism330dl", "lis2mdl"):
         sleep_ms(200)
     raw = sensor.temperature()
     offset = ref_temp - raw
@@ -63,7 +63,7 @@ verify_sensors = [
 
 print("\nVerification (after reload):")
 for name, sensor in verify_sensors:
-    if name == "ism330dl":
+    if name in ("ism330dl", "lis2mdl"):
         sleep_ms(200)
     config2.apply_temperature_calibration(sensor)
     print("  {:10s}: {:6.2f} C".format(name, sensor.temperature()))


### PR DESCRIPTION
## Summary

Simplify `calibrate_temperature.py` example by removing RAM management hacks that were needed before drivers were frozen into the firmware.

Closes #248

## Changes

**Removed:**
- `sys.modules.pop()` / `__import__()` pattern for loading/unloading drivers one at a time
- `gc.collect()` calls between sensor reads
- Dynamic module import via string names

**Replaced with:**
- Direct `from xxx import XXX` imports (drivers are in ROM, not RAM)
- Simple list of `(name, sensor_instance)` tuples
- Added docstring note about requiring frozen firmware (`make firmware && make deploy`)

## Related
- PR #246 — Firmware build and deploy targets (merged)
- Issue #175 — RAM pressure investigation

## Test plan

- [x] `make lint` passes
- [ ] `make run SCRIPT=lib/steami_config/examples/calibrate_temperature.py` on hardware