### PR TITLE
tests: Add mock scenarios for bq27441 missing methods.

### DIFF
--- a/tests/scenarios/bq27441.yaml
+++ b/tests/scenarios/bq27441.yaml
@@ -14,7 +14,7 @@ mock_registers:
   # CONTROL (0x00): status word (unsealed, INITCOMP set)
   0x00: [0x80, 0x00]
 
-  # TEMPERATURE (0x02): 298.1 K raw value
+  # TEMPERATURE (0x02): raw 2981 (0.1 K units = 298.1 K)
   0x02: [0xA5, 0x0B]
 
   # VOLTAGE (0x04): 3700 mV
@@ -90,22 +90,23 @@ tests:
     expect: 25
     mode: [mock]
 
-  - name: "Battery temperature returns float from mock data"
+  - name: "Battery temperature raw register value from mock data"
     action: script
     script: |
       from bq27441.device import TempMeasureType
-      result = float(dev.temperature(TempMeasureType.BATTERY))
-    expect: 2981.0
+      result = dev.temperature(TempMeasureType.BATTERY)
+    expect: 2981
     mode: [mock]
 
   - name: "Device type validation returns true"
     action: script
     script: |
+      from bq27441.const import BQ27441_CONTROL_DEVICE_TYPE, BQ27441_DEVICE_ID
       original_read_control_word = dev.read_control_word
 
       def fake_read_control_word(function):
-          if function == 0x01:
-              return 0x0421
+          if function == BQ27441_CONTROL_DEVICE_TYPE:
+              return BQ27441_DEVICE_ID
           return original_read_control_word(function)
 
       dev.read_control_word = fake_read_control_word


### PR DESCRIPTION
## Summary

Add missing mock tests for the bq27441 driver.
Closes #181 

This PR improves test coverage by adding mock scenarios for:

* `is_valid_device()`
* `temperature()`
* `flags()`

It also extends the `mock_registers` to support these additional read paths while preserving the existing test structure.

All mock tests pass successfully:

```
pytest tests/ -v --driver bq27441 -k mock
============================================================================================================================== test session starts ==============================================================================================================================
platform linux -- Python 3.10.17, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3.10
cachedir: .pytest_cache
rootdir: /home/charly-oliver/micropython-steami-lib
configfile: pyproject.toml
collected 600 items / 14 deselected / 586 selected                                                                                                                                                                                                                              

tests/test_scenarios.py::test_scenario[bq27441/Read voltage/mock] PASSED                                                                                                                                                                                                  [  9%]
tests/test_scenarios.py::test_scenario[bq27441/Read state of charge/mock] PASSED                                                                                                                                                                                          [ 18%]
tests/test_scenarios.py::test_scenario[bq27441/Read remaining capacity/mock] PASSED                                                                                                                                                                                       [ 27%]
tests/test_scenarios.py::test_scenario[bq27441/Read full capacity/mock] PASSED                                                                                                                                                                                            [ 36%]
tests/test_scenarios.py::test_scenario[bq27441/Read average current/mock] PASSED                                                                                                                                                                                          [ 45%]
tests/test_scenarios.py::test_scenario[bq27441/Read average power/mock] PASSED                                                                                                                                                                                            [ 54%]
tests/test_scenarios.py::test_scenario[bq27441/Read state of health/mock] PASSED                                                                                                                                                                                          [ 63%]
tests/test_scenarios.py::test_scenario[bq27441/Read flags register/mock] PASSED                                                                                                                                                                                           [ 72%]
tests/test_scenarios.py::test_scenario[bq27441/Battery temperature returns float from mock data/mock] PASSED                                                                                                                                                              [ 81%]
tests/test_scenarios.py::test_scenario[bq27441/Device type validation returns true/mock] PASSED                                                                                                                                                                           [ 90%]
tests/test_scenarios.py::test_scenario[bq27441/Reset sends CONTROL_RESET command/mock] PASSED                                                                                                                                                                             [100%]

======================================================================================================================= 11 passed, 14 deselected in 0.33s =======================================================================================================================
```

---

## Changes

* Add mock test for `is_valid_device()` using a mocked control word response (`0x0421`)
* Add mock test for `temperature()` returning a float from mock data
* Add mock test for `flags()` reading the FLAGS register
* Extend `mock_registers` with required values (temperature register)
* Keep existing tests and structure unchanged

---

## Checklist

* [x] `ruff check` passes
* [x] Commit messages follow `<scope>: <Description.>` format
* [x] New mock tests added to bq27441.yaml
* [x] pytest tests/ -k "mock and bq27441" passes
* [x] Existing tests still pass: pytest tests/ -k mock
