### PR TITLE
fix(examples): Migrate buzzer tone() to hardware PWM Timer.

### DIFF
--- a/lib/mcp23009e/examples/dpad_piano.py
+++ b/lib/mcp23009e/examples/dpad_piano.py
@@ -58,7 +58,7 @@ NOTES_HIGH = {
 def tone(freq):
     """Start a tone using hardware PWM."""
     if freq <= 0:
-        buzzer_ch.pulse_width_percent(0)
+        no_tone()
         return
     buzzer_tim.freq(freq)
     buzzer_ch.pulse_width_percent(50)
@@ -123,7 +123,7 @@ def dpad_piano():
 
     last_note = None
     last_octave = None
-    last_freq = None
+    last_freq = 0
 
     try:
         while True:


### PR DESCRIPTION
## Summary

Replace the blocking software-based `tone()` implementation in `dpad_piano.py` with a hardware PWM-based approach using Timer 1.

Closes #254 

---

## Changes

* Replace GPIO bit-banging (`sleep_us` loop) with hardware PWM (TIM1_CH4 on PA11 / SPEAKER)
* Add non-blocking `tone()` and `no_tone()` functions using Timer PWM
* Improve responsiveness of D-PAD and MENU buttons while playing notes
* Align implementation with `metal_detector.py` example (already using PWM)

---

## Checklist

* [x] `ruff check` passes
* [x] Tested on hardware (if applicable)
* [x] Examples added/updated (if applicable)
* [x] Commit messages follow `<scope>: <Description.>` format
