### PR TITLE
fix(bq27441): Harmonize temperature() return value with project convention.

### DIFF
--- a/lib/bq27441/README.md
+++ b/lib/bq27441/README.md
@@ -209,4 +209,4 @@ mpremote mount lib/bq27441 run lib/bq27441/examples/fuel_gauge.py
 * Default design capacity is 650 mAh (configurable via `set_capacity()`).
 * Some configuration operations require entering config mode with `enter_config()`.
 * The device may be sealed; use `unseal()` before advanced configuration.
-* Temperature readings are raw register values in 0.1 K units (see conversion above).
+* `temperature()` returns °C by default. Use `temperature_k()` for Kelvin or `temperature_dk()` for raw decikelvin.

--- a/lib/bq27441/bq27441/device.py
+++ b/lib/bq27441/bq27441/device.py
@@ -247,7 +247,8 @@ class BQ27441(object):
             return self.read_word(BQ27441_COMMAND_TEMP)
         elif temp_measure_type == TempMeasureType.INTERNAL_TEMP:
             return self.read_word(BQ27441_COMMAND_INT_TEMP)
-        return 0
+        else:
+            raise ValueError("Unsupported TempMeasureType: {!r}".format(temp_measure_type))
 
     def temperature(self, temp_measure_type=TempMeasureType.BATTERY):
         return self._read_temperature_dk(temp_measure_type) / 10.0 - 273.15

--- a/tests/scenarios/bq27441.yaml
+++ b/tests/scenarios/bq27441.yaml
@@ -101,7 +101,7 @@ tests:
     action: script
     script: |
       result = dev.temperature_k()
-    expect: 298.1
+    expect_range: [298.09, 298.11]
     mode: [mock]
 
   - name: "Battery temperature in decikelvin"


### PR DESCRIPTION
## Summary

- `temperature()` now returns degrees Celsius (convention), with `TempMeasureType.BATTERY` as default
- Added `temperature_k()` returning Kelvin and `temperature_dk()` returning raw decikelvin
- Updated mock tests and README accordingly

Closes #255

## Test plan

- [x] `ruff check` passes
- [x] All 13 bq27441 mock tests pass
- [x] Hardware validation on STeaMi board