### PR TITLE
ci: Add explicit permissions to CI workflows.

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   check-commit-messages:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-linter.yml
+++ b/.github/workflows/python-linter.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   mock-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` to all three CI workflows
- Fixes CodeQL alerts #1, #2, #3 (`actions/missing-workflow-permissions`)

Workflows without explicit permissions default to the repository's default token permissions, which may be overly broad. Setting `contents: read` follows the principle of least privilege.

Closes #277

## Test plan

- [x] All three workflows updated: `tests.yml`, `check-commits.yml`, `python-linter.yml`
- [ ] CI passes on this PR