### PR TITLE
ci: Fix Dependabot alerts by upgrading handlebars to 4.7.9.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1587,9 +1587,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3539,9 +3539,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Upgrade handlebars from 4.7.8 to 4.7.9 via `npm audit fix`
- Fixes 5 Dependabot alerts (GHSA-f886-m6hf-6m8v, GHSA-xxjr-mmjv-4gpg, GHSA-3v7f-55p6-f55p, GHSA-c2c7-rcm5-vvqj, GHSA-52f5-9888-hmc6) for JavaScript injection and prototype pollution in handlebars

## Remaining alerts (not fixable)

The following vulnerabilities are in deeply nested transitive dependencies and cannot be fixed without upstream releases:

| Package | Severity | Reason |
|---------|----------|--------|
| picomatch 4.0.3 | high | Bundled inside npm internal (`@semantic-release/npm` → `npm`) |
| lodash 4.17.21 | moderate | Inside `commitizen` (no fix released) |
| brace-expansion 2.0.2 | moderate | Bundled inside npm internal |
| tmp 0.2.3 | low | Inside `commitizen` → `inquirer` |

## Test plan

- [x] `npm audit fix` applied
- [x] handlebars upgraded to 4.7.9
- [ ] CI passes