### PR TITLE
docs: Add security policy.

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -7,7 +7,7 @@
 | latest release | Yes |
 | older releases | No |
 
-Only the latest release on the `main` branch receives security updates.
+Only the most recent tagged release receives security updates.
 
 ## Reporting a Vulnerability
 
@@ -37,12 +37,12 @@ This policy covers the MicroPython driver library code in `lib/` and the build/C
 
 * The MicroPython firmware itself (report upstream at [micropython/micropython](https://github.com/micropython/micropython))
 * The STeaMi board hardware
-* Third-party npm dependencies (report upstream to the respective package maintainers)
+* Third-party dependencies (npm packages, Python packages — report upstream to the respective package maintainers)
 
 ## Automated Security
 
-This repository uses:
+This repository has the following GitHub security features enabled:
 
-* **Dependabot** for automated dependency vulnerability alerts
-* **CodeQL** for static analysis on CI workflows
+* **Dependabot alerts** for dependency vulnerability detection
+* **CodeQL analysis** for static security analysis
 * **Secret scanning** for detecting leaked credentials


### PR DESCRIPTION
## Summary

Add `.github/SECURITY.md` with:

- Supported versions (most recent tagged release only)
- How to report vulnerabilities (GitHub Security Advisories or email)
- What to include in a report
- Response timeline (7 days ack, 30 days fix)
- Scope (driver library and tooling, not firmware, hardware, or third-party deps)
- Automated security features in use (Dependabot alerts, CodeQL analysis, secret scanning)

Once merged, GitHub will display a "Security policy" link on the repository's Security tab.

Closes #282

## Test plan

- [x] SECURITY.md follows GitHub's expected path (`.github/SECURITY.md`)
- [x] Report link points to the correct advisory URL