### PR TITLE
ci: Attach firmware hex and bin to GitHub releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,8 @@ jobs:
         run: |
           VERSION="v${{ needs.release.outputs.new-release-version }}"
           BUILD_DIR=".build/micropython-steami/ports/stm32/build-STEAM32_WB55RG"
-          cp "${BUILD_DIR}/firmware.hex" "steami-firmware-${VERSION}.hex"
-          cp "${BUILD_DIR}/firmware.bin" "steami-firmware-${VERSION}.bin"
+          cp "${BUILD_DIR}/firmware.hex" "steami-micropython-firmware-${VERSION}.hex"
+          cp "${BUILD_DIR}/firmware.bin" "steami-micropython-firmware-${VERSION}.bin"
           gh release upload "$VERSION" \
             "steami-micropython-firmware-${VERSION}.hex" \
             "steami-micropython-firmware-${VERSION}.bin" \

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -25,7 +25,7 @@
     }],
     ["@semantic-release/exec", {
       "prepareCmd": "sed -i 's/^version = \".*\"/version = \"${nextRelease.version}\"/' pyproject.toml",
-      "publishCmd": "echo new-release-published=true >> $GITHUB_OUTPUT && echo new-release-version=${nextRelease.version} >> $GITHUB_OUTPUT"
+      "publishCmd": "[ -n \"${GITHUB_OUTPUT:-}\" ] && { echo 'new-release-published=true' >>\"$GITHUB_OUTPUT\"; echo \"new-release-version=${nextRelease.version}\" >>\"$GITHUB_OUTPUT\"; } || true"
     }],
     ["@semantic-release/git", {
       "assets": ["CHANGELOG.md", "pyproject.toml"],


### PR DESCRIPTION
## Summary

Add a `firmware` job to the release workflow that builds MicroPython firmware with frozen drivers and attaches both `.hex` and `.bin` files to each GitHub release.

### How it works

1. **Semantic release** runs and creates a new release (if commits warrant it)
2. `@semantic-release/exec` `publishCmd` writes `new-release-published` and `new-release-version` to `$GITHUB_OUTPUT`
3. **Firmware job** runs only if a new release was published (`if: needs.release.outputs.new-release-published == 'true'`)
4. Checks out the release tag, installs ARM toolchain, clones micropython-steami, links drivers, builds
5. Attaches `steami-firmware-vX.Y.Z.hex` and `steami-firmware-vX.Y.Z.bin` to the GitHub release

### Files changed

- `.github/workflows/release.yml`: added `outputs` on release job, added `firmware` job
- `.releaserc.json`: added `publishCmd` to `@semantic-release/exec` for GitHub Actions outputs

Closes #283

## Test plan

- [ ] CI passes on this PR
- [ ] Next release on main triggers firmware build and attaches .hex and .bin