### PR TITLE
tooling: Lower Pylint complexity thresholds in ruff.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,21 +96,21 @@ ignore = [
 known-third-party = ["micropython"]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 61
+max-complexity = 25
 
 [tool.ruff.lint.pylint]
 allow-magic-value-types = ["bytes", "int", "str"]
-max-args = 14
-max-branches = 58
-max-returns = 13
-max-statements = 166
+max-args = 10
+max-branches = 25
+max-returns = 8
+max-statements = 65
 
 [tool.ruff.lint.per-file-ignores]
 # manifest.py files are evaluated with some global names pre-defined
 "**/manifest.py" = ["F821"]
 "**/examples/*.py" = ["T20", "N806"]
 "lib/mcp23009e/examples/i2c_scan.py" = ["PERF203"]
-"tests/**/*.py" = ["T20"]
+"tests/**/*.py" = ["T20", "PLR0911", "PLR0912", "PLR0915"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Summary

Lower the Pylint complexity thresholds from their current permissive values to just above the worst existing violations. This prevents new complex code from being introduced while accepting the existing codebase.

| Setting | Before | After | Worst violation |
|---------|--------|-------|-----------------|
| max-complexity (McCabe) | 61 | 25 | 22 (apds9960 `process_gesture_data`) |
| max-args | 14 | 10 | 8 (steami_config mag calibration) |
| max-branches | 58 | 25 | 24 (apds9960 `process_gesture_data`) |
| max-returns | 13 | 8 | 7 (ism330dl `orientation`) |
| max-statements | 166 | 65 | 64 (apds9960 `process_gesture_data`) |

Test infrastructure files (`tests/`) are exempt from PLR0911/PLR0912/PLR0915 as the test runner and report plugin inherently have complex control flow.

The main offender is `apds9960.process_gesture_data` which is a ported driver with inherently complex gesture recognition logic. Refactoring it is out of scope for this PR.

Closes #291

## Test plan

- [x] `make ci` passes
- [x] No new code can exceed these thresholds without explicit review