### PR TITLE
test(lis2mdl,apds9960): Add mock scenarios for calibration, heading, gesture, and setters.

### DIFF
--- a/tests/scenarios/apds9960.yaml
+++ b/tests/scenarios/apds9960.yaml
@@ -249,10 +249,11 @@ tests:
     expect_true: true
     mode: [mock]
 
-  - name: "is_gesture_available returns bool"
+  - name: "is_gesture_available returns False when GSTATUS not set"
     action: script
     script: |
-      result = isinstance(dev.is_gesture_available(), bool)
+      # Mock GSTATUS (0xAF) not configured, so GVALID bit is 0
+      result = dev.is_gesture_available() is False
     expect_true: true
     mode: [mock]
 
@@ -328,24 +329,27 @@ tests:
     expect_true: true
     mode: [mock]
 
-  - name: "data_ready returns bool"
+  - name: "data_ready returns True when status indicates valid data"
     action: script
     script: |
-      result = isinstance(dev.data_ready(), bool)
+      # Mock STATUS register is 0x03 (AVALID + PVALID set)
+      result = dev.data_ready() is True
     expect_true: true
     mode: [mock]
 
-  - name: "light_ready returns bool"
+  - name: "light_ready returns True when AVALID set"
     action: script
     script: |
-      result = isinstance(dev.light_ready(), bool)
+      # Mock STATUS register is 0x03 (AVALID bit set)
+      result = dev.light_ready() is True
     expect_true: true
     mode: [mock]
 
-  - name: "proximity_ready returns bool"
+  - name: "proximity_ready returns True when PVALID set"
     action: script
     script: |
-      result = isinstance(dev.proximity_ready(), bool)
+      # Mock STATUS register is 0x03 (PVALID bit set)
+      result = dev.proximity_ready() is True
     expect_true: true
     mode: [mock]
 

--- a/tests/scenarios/lis2mdl.yaml
+++ b/tests/scenarios/lis2mdl.yaml
@@ -189,11 +189,12 @@ tests:
     expect_true: true
     mode: [mock]
 
-  - name: "read_hw_offsets returns tuple of 3"
+  - name: "read_hw_offsets returns zeros from mock registers"
     action: script
     script: |
       ox, oy, oz = dev.read_hw_offsets()
-      result = isinstance(ox, int) and isinstance(oy, int) and isinstance(oz, int)
+      # Mock registers initialize all offset bytes to 0x00
+      result = (ox, oy, oz) == (0, 0, 0)
     expect_true: true
     mode: [mock]
 
@@ -364,10 +365,11 @@ tests:
     expect_true: true
     mode: [mock]
 
-  - name: "data_ready returns bool"
+  - name: "data_ready returns True when status has Zyxda set"
     action: script
     script: |
-      result = isinstance(dev.data_ready(), bool)
+      # Mock STATUS_REG is 0x0F (Zyxda bit set)
+      result = dev.data_ready() is True
     expect_true: true
     mode: [mock]
 


### PR DESCRIPTION
## Summary

Add mock test scenarios for LIS2MDL calibration/heading and APDS9960 gesture/setters.

### LIS2MDL: 22 new tests (15 → 37 mock tests)

| Category | Tests |
|----------|-------|
| Calibration | set_heading_offset, set_declination, set_hw_offsets, read_hw_offsets, calibrated_field (with offsets+scales), calibrate_reset, read_calibration |
| Heading | heading_flat_only, heading_with_tilt_compensation, heading_from_vectors, heading offset shift (~90°), declination shift (~45°), direction_label N, direction_label E |
| Mode/config | set_mode continuous/idle, set_odr, power_on, is_idle, data_ready, magnetic_field_raw |
| Diagnostic | read_all returns expected keys |

### APDS9960: 26 new tests (9 → 35 mock tests)

| Category | Tests |
|----------|-------|
| Setter/getter round-trips | proximity_gain, ambient_light_gain, led_drive, led_boost, prox_int_low/high_thresh, gesture_gain, gesture_led_drive, gesture_enter/exit_thresh, gesture_wait_time, light_int_low/high_threshold, gesture_mode, proximity_int_enable, ambient_light_int_enable |
| Gesture sensor | enable sets GEN+PON bits, disable clears GEN bit, is_gesture_available |
| Power | power_off clears PON, power_on sets PON |
| Readiness | data_ready, light_ready, proximity_ready |
| Color channels | green_light, blue_light |

### Not covered (by design)

**LIS2MDL**: Hardware config setters (`set_low_pass`, `set_bdu`, `set_endianness`, `use_spi_4wire`) and interactive calibrations (`calibrate_minmax_2d/3d` require physical rotation).

**APDS9960**: Internal gesture pipeline (`process_gesture_data`, `decode_gesture`) and advanced masks (`prox_photo_mask`, `prox_gain_comp`).

Closes #260, closes #259

## Test plan

- [x] 37 LIS2MDL mock tests pass
- [x] 35 APDS9960 mock tests pass
- [x] `make ci` passes