### PR TITLE
feat(bme280): Add measurement modes and sensor configuration

### DIFF
--- a/lib/bme280/bme280/device.py
+++ b/lib/bme280/bme280/device.py
@@ -182,13 +182,14 @@ class BME280(object):
         """
         if humidity is not None:
             self._write_reg(REG_CTRL_HUM, humidity)
-        if temperature is not None or pressure is not None:
-            ctrl = self._read_reg(REG_CTRL_MEAS)
-            if temperature is not None:
-                ctrl = (ctrl & ~(0x07 << OSRS_T_SHIFT)) | (temperature << OSRS_T_SHIFT)
-            if pressure is not None:
-                ctrl = (ctrl & ~(0x07 << OSRS_P_SHIFT)) | (pressure << OSRS_P_SHIFT)
-            self._write_reg(REG_CTRL_MEAS, ctrl)
+        ctrl = self._read_reg(REG_CTRL_MEAS)
+        if temperature is not None:
+            ctrl = (ctrl & ~(0x07 << OSRS_T_SHIFT)) | (temperature << OSRS_T_SHIFT)
+        if pressure is not None:
+            ctrl = (ctrl & ~(0x07 << OSRS_P_SHIFT)) | (pressure << OSRS_P_SHIFT)
+        # ctrl_meas must always be rewritten: changes to ctrl_hum are only
+        # latched when ctrl_meas is written (datasheet section 5.4.3).
+        self._write_reg(REG_CTRL_MEAS, ctrl)
 
     def set_iir_filter(self, coefficient):
         """Configure the IIR filter coefficient.

--- a/tests/scenarios/bme280.yaml
+++ b/tests/scenarios/bme280.yaml
@@ -356,7 +356,7 @@ tests:
     expect_true: true
     mode: [mock]
 
-  - name: "set_oversampling configures humidity"
+  - name: "set_oversampling configures humidity and latches via ctrl_meas"
     action: script
     script: |
       from bme280.const import OSRS_X8
@@ -364,7 +364,17 @@ tests:
       dev.set_oversampling(humidity=OSRS_X8)
       log = i2c.get_write_log()
       hum_writes = [data[0] for reg, data in log if reg == 0xF2]
-      result = len(hum_writes) == 1 and hum_writes[0] == OSRS_X8
+      # ctrl_meas must be rewritten after ctrl_hum for the change to take effect
+      ctrl_writes = [data[0] for reg, data in log if reg == 0xF4]
+      # Verify write order: ctrl_hum (0xF2) must come before ctrl_meas (0xF4)
+      hum_idx = next(i for i, (reg, _) in enumerate(log) if reg == 0xF2)
+      meas_idx = next(i for i, (reg, _) in enumerate(log) if reg == 0xF4)
+      result = (
+          len(hum_writes) == 1
+          and hum_writes[0] == OSRS_X8
+          and len(ctrl_writes) == 1
+          and hum_idx < meas_idx
+      )
     expect_true: true
     mode: [mock]
 


### PR DESCRIPTION
Closes #306

## Summary

- **Power control**: `power_off()` (sleep mode), `power_on()` (normal mode)
- **Continuous mode**: `set_continuous(standby=None)` — enters normal mode with optional standby time
- **Oversampling**: `set_oversampling(temperature=, pressure=, humidity=)` — per-channel config via `OSRS_SKIP..OSRS_X16`
- **IIR filter**: `set_iir_filter(coefficient)` — `FILTER_OFF..FILTER_16`
- **Standby time**: `set_standby(standby)` — `STANDBY_0_5_MS..STANDBY_1000_MS`
- All configuration methods use read-modify-write to preserve unrelated register bits
- **10 new mock tests** covering mode transitions, oversampling config, filter/standby config, and bit preservation

Note: `trigger_one_shot()` and `read_one_shot()` were already implemented in #312 (issue #305).

## Test plan

- [x] 31 mock tests pass (`make test-bme280`)
- [ ] Hardware validation (issue #307)