### PR TITLE
feat(bme280): Add altitude computation and sea-level pressure

### DIFF
--- a/lib/bme280/README.md
+++ b/lib/bme280/README.md
@@ -171,10 +171,17 @@ alt = sensor.altitude()
 
 Returns the estimated altitude in **meters** using the ICAO barometric formula.
 
-The computation uses `sea_level_pressure` as reference (default: 1013.25 hPa). Adjust it for your location:
+You can also pass an already-read pressure value to avoid a redundant I2C read:
 
 ```python
-sensor.sea_level_pressure = 1020.0  # local sea-level pressure in hPa
+temperature, pressure, humidity = sensor.read()
+alt = sensor.altitude(pressure_hpa=pressure)
+```
+
+The computation uses `sea_level_pressure_hpa` as reference (default: 1013.25 hPa). Adjust it for your location:
+
+```python
+sensor.sea_level_pressure_hpa = 1020.0
 ```
 
 ---

--- a/lib/bme280/bme280/device.py
+++ b/lib/bme280/bme280/device.py
@@ -39,7 +39,7 @@ class BME280(object):
     def __init__(self, i2c, address=BME280_I2C_DEFAULT_ADDR):
         self.i2c = i2c
         self.address = address
-        self.sea_level_pressure = 1013.25
+        self.sea_level_pressure_hpa = 1013.25
         self._check_device()
         self._wait_boot()
         self._read_calibration()
@@ -397,11 +397,15 @@ class BME280(object):
         hum_rh = self._compensate_humidity(raw_hum) / 1024.0
         return temp_c, press_hpa, hum_rh
 
-    def altitude(self):
-        """Return estimated altitude in meters from current pressure.
+    def altitude(self, pressure_hpa=None):
+        """Return estimated altitude in meters.
 
-        Uses the ICAO barometric formula with ``sea_level_pressure`` as
-        reference (default 1013.25 hPa, adjustable).
+        Uses the ICAO barometric formula with ``sea_level_pressure_hpa``
+        as reference (default 1013.25 hPa, adjustable).
+
+        Args:
+            pressure_hpa: pressure in hPa. If None, a new reading is taken
+                          via :meth:`pressure_hpa`.
         """
-        p = self.pressure_hpa()
-        return 44330.0 * (1.0 - (p / self.sea_level_pressure) ** 0.1903)
+        p = self.pressure_hpa() if pressure_hpa is None else pressure_hpa
+        return 44330.0 * (1.0 - (p / self.sea_level_pressure_hpa) ** 0.1903)

--- a/lib/bme280/examples/weather_station.py
+++ b/lib/bme280/examples/weather_station.py
@@ -20,7 +20,7 @@ bridge = DaplinkBridge(i2c)
 flash = DaplinkFlash(bridge)
 
 # Adjust sea-level pressure to local conditions for accurate altitude
-# sensor.sea_level_pressure = 1020.0
+# sensor.sea_level_pressure_hpa = 1020.0
 
 # Configure for weather monitoring: high pressure resolution, moderate temp/hum
 sensor.set_oversampling(temperature=OSRS_X2, pressure=OSRS_X16, humidity=OSRS_X2)
@@ -37,7 +37,7 @@ flash.write_line("temperature;pressure;humidity;altitude")
 
 while True:
     temperature, pressure, humidity = sensor.read()
-    alt = sensor.altitude()
+    alt = sensor.altitude(pressure_hpa=pressure)
 
     print(
         "T: {:.1f} C  P: {:.1f} hPa  H: {:.1f} %RH  Alt: {:.0f} m".format(

--- a/tests/scenarios/bme280.yaml
+++ b/tests/scenarios/bme280.yaml
@@ -584,10 +584,10 @@ tests:
 
   # ----- Altitude -----
 
-  - name: "Default sea_level_pressure is 1013.25"
+  - name: "Default sea_level_pressure_hpa is 1013.25"
     action: script
     script: |
-      result = dev.sea_level_pressure == 1013.25
+      result = dev.sea_level_pressure_hpa == 1013.25
     expect_true: true
     mode: [mock]
 
@@ -600,14 +600,14 @@ tests:
     expect_true: true
     mode: [mock]
 
-  - name: "altitude() uses custom sea_level_pressure"
+  - name: "altitude() uses custom sea_level_pressure_hpa"
     action: script
     script: |
-      dev.sea_level_pressure = 1020.0
+      dev.sea_level_pressure_hpa = 1020.0
       alt = dev.altitude()
       # Mock pressure ~1009.21 hPa → altitude ~89.6 m at 1020.0 hPa reference
       result = abs(alt - 89.6) < 1.0
-      dev.sea_level_pressure = 1013.25
+      dev.sea_level_pressure_hpa = 1013.25
     expect_true: true
     mode: [mock]
 
@@ -615,9 +615,18 @@ tests:
     action: script
     script: |
       # Set reference to match actual pressure so altitude should be ~0
-      dev.sea_level_pressure = dev.pressure_hpa()
+      dev.sea_level_pressure_hpa = dev.pressure_hpa()
       alt = dev.altitude()
       result = abs(alt) < 0.5
-      dev.sea_level_pressure = 1013.25
+      dev.sea_level_pressure_hpa = 1013.25
+    expect_true: true
+    mode: [mock]
+
+  - name: "altitude() accepts pressure_hpa parameter"
+    action: script
+    script: |
+      # Pass pressure directly to avoid redundant I2C read
+      alt = dev.altitude(pressure_hpa=1009.21)
+      result = abs(alt - 33.7) < 1.0
     expect_true: true
     mode: [mock]


### PR DESCRIPTION
Closes #315

## Summary

- **`sea_level_pressure`** attribute: initialized to 1013.25 hPa, user-adjustable for local conditions
- **`altitude()`** method: estimates altitude in meters using the ICAO barometric formula `44330 * (1 - (P/P0)^0.1903)` — same formula used by robert-hh, Adafruit, and Pimoroni
- **`weather_station.py`** updated: uses `sensor.altitude()` instead of a local `altitude_m()` function; sea-level pressure configured via `sensor.sea_level_pressure`
- **README** updated: new Altitude section in API reference, comparison table updated (Altitude and Sea-level pressure now ✅)
- **4 new mock tests**: default reference value, altitude with default/custom reference, altitude=0 when pressure matches reference

## Test plan

- [x] 52 mock tests pass (`make test-bme280`)
- [ ] Hardware validation