### PR TITLE
feat(vl53l1x): Add proximity alert example with buzzer.

### DIFF
--- a/lib/vl53l1x/examples/proximity_alert.py
+++ b/lib/vl53l1x/examples/proximity_alert.py
@@ -1,3 +1,9 @@
+"""Proximity alert using VL53L1X distance sensor and buzzer.
+
+Beeps the buzzer when an object is detected within 200 mm. The pitch
+increases as the object gets closer.
+"""
+
 from time import sleep_ms
 
 from machine import I2C, Pin
@@ -6,11 +12,11 @@ from vl53l1x import VL53L1X
 
 DISTANCE_THRESHOLD_MM = 200
 
-# sensor configuration
+# Sensor configuration
 i2c = I2C(1)
 tof = VL53L1X(i2c)
 
-#buzzer initialisation
+# Buzzer initialisation
 buzzer_tim = Timer(1, freq=1000)
 buzzer_ch = buzzer_tim.channel(4, Timer.PWM, pin=Pin("SPEAKER"))
 buzzer_ch.pulse_width_percent(0)
@@ -21,9 +27,9 @@ try:
         print("Distance: {} mm".format(distance))
 
         if distance < DISTANCE_THRESHOLD_MM:
-            #frequency ranging from 1500 (really close) to 500 (at 200mm)
-            freq = (1500- (distance * 5))
-            #security limits
+            # Frequency ranging from 1500 (really close) to 500 (at 200mm)
+            freq = 1500 - (distance * 5)
+            # Security limits
             freq = max(500, min(1500, freq))
 
             buzzer_tim.freq(freq)
@@ -31,9 +37,9 @@ try:
         else:
             buzzer_ch.pulse_width_percent(0)
 
-
         sleep_ms(50)
 
-
 except KeyboardInterrupt:
-    buzzer_ch.pulse_width_percent(0) #Properly cut the sound when the user presses CTLR+C
+    pass
+finally:
+    buzzer_ch.pulse_width_percent(0)


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Reference the issue: Closes #XXX -->
Add a `proximity_alert.py` example for the VL53L1X sensor driver. This script triggers a PWM buzzer when the measured distance falls below a defined threshold (200 mm), with the pitch dynamically adapting to the object's proximity.
Closes #325 

## Changes

<!-- List the main changes -->

- Created the `lib/vl53l1x/examples/proximity_alert.py` file.
- Initialized the VL53L1X sensor over I2C and added a continuous distance reading loop.
- Configured the buzzer using hardware PWM on the `SPEAKER` pin.
- Added logic to vary the beep frequency (from 1500 Hz when close, down to 500 Hz at 200 mm) based on the measured distance.
- Included a `try...except KeyboardInterrupt` block to ensure the sound is properly turned off when the user stops the script with Ctrl+C.

## Checklist

- [x] `ruff check` passes
- [x] `python -m pytest tests/ -k mock -v` passes (no mock test broken)
- [x] Tested on hardware (if applicable)
- [ ] README updated (if adding/changing public API)
- [x] Examples added/updated (if applicable)
- [x] Commit messages follow `<scope>: <Description.>` format
