### PR TITLE
feat(vl53l1x): Add radar screen example with OLED.

### DIFF
--- a/lib/vl53l1x/examples/radar_screen.py
+++ b/lib/vl53l1x/examples/radar_screen.py
@@ -13,6 +13,17 @@ from vl53l1x import VL53L1X
 
 MAX_DISTANCE_MM = 1000
 
+# Layout constants for the round screen
+BAR_X = 24
+BAR_Y = 70
+BAR_MAX_WIDTH = 80
+BAR_HEIGHT = 15
+TEXT_LBL_X = 28
+TEXT_LBL_Y = 35
+TEXT_VAL_X = 36
+TEXT_VAL_Y = 50
+TEXT_OUT_X = 16  # Shifted left to fit the longer "Out of range" text
+
 i2c = I2C(1)
 tof = VL53L1X(i2c)
 
@@ -30,29 +41,29 @@ try:
         # Clear the display frame buffer
         display.fill(0)
 
-        # Clamp distance to maximum range to avoid negative ratios
+        # Clamp distance to maximum range and compute integer proximity
         clamped_dist = max(0, min(distance, MAX_DISTANCE_MM))
+        proximity = MAX_DISTANCE_MM - clamped_dist
 
-        # Calculate ratio (1.0 = extremely close, 0.0 = MAX_DISTANCE_MM or further)
-        ratio = 1.0 - (clamped_dist / MAX_DISTANCE_MM)
-
-        # Map ratio to a maximum width of 80 pixels (to fit the round screen) and brightness (15 levels)
-        bar_width = int(80 * ratio)
-        brightness = int(15 * ratio)
+        # Map proximity to bar width (max 80px) and brightness (max 15)
+        bar_width = (80 * proximity) // MAX_DISTANCE_MM
+        brightness = (15 * proximity) // MAX_DISTANCE_MM
 
         # If the object is within the detection range, ensure minimum visibility
-        if distance < MAX_DISTANCE_MM:
+        if distance <= MAX_DISTANCE_MM:
             bar_width = max(1, bar_width)
             brightness = max(1, brightness)
 
         # Draw the outline box (1 pixel larger than the max bar size) at max brightness
-        display.framebuf.rect(23, 69, 82, 17, 15)
+        display.framebuf.rect(BAR_X - 1, BAR_Y - 1, BAR_MAX_WIDTH + 2, BAR_HEIGHT + 2, 15)
         # Draw the distance bar centered: x=24, y=70, max_width=80, height=15
-        display.framebuf.fill_rect(24, 70, bar_width, 15, brightness)
+        display.framebuf.fill_rect(BAR_X, BAR_Y, bar_width, BAR_HEIGHT, brightness)
 
-        # Display the text information centered in the round screen
-        display.text("Distance:", 28, 35, 15)
-        display.text("{} mm".format(distance), 36, 50, 15)
+        # Display distance or "Out of range"
+        if distance > MAX_DISTANCE_MM:
+            display.text("Out of range", TEXT_OUT_X, TEXT_VAL_Y, 15)
+        else:
+            display.text("{} mm".format(distance), TEXT_VAL_X, TEXT_VAL_Y, 15)
 
         # Send the buffer to the physical screen
         display.show()


### PR DESCRIPTION
## Summary

Add a `radar_screen.py` example for the VL53L1X sensor. It displays a real-time distance bar on the SSD1327 OLED screen using the SPI bus. The closer the object, the longer and brighter the bar. The layout has been specifically adapted for a round display bezel, including a static outline frame to indicate the maximum range. 

Closes #326 

## Changes

- Created `lib/vl53l1x/examples/radar_screen.py`.
- Initialized the VL53L1X sensor over I2C and the SSD1327 OLED display over SPI.
- Implemented a continuous loop mapping the distance to a horizontal bar's width (up to 80 pixels to fit the round screen) and brightness (1 to 15 grayscale levels).
- Added a minimum visibility clamp to ensure at least 1 pixel/brightness level is shown when an object is within the 1000 mm detection range.
- Added a bounding box (`framebuf.rect`) around the filled bar (`framebuf.fill_rect`) to clearly show the scale.
- Included a `try...finally` block to ensure the OLED screen is properly cleared when the script is interrupted.

## Checklist

- [x] `ruff check` passes
- [x] `python -m pytest tests/ -k mock -v` passes (no mock test broken)
- [x] Tested on hardware (if applicable)
- [ ] README updated (if adding/changing public API)
- [x] Examples added/updated (if applicable)
- [x] Commit messages follow `<scope>: <Description.>` format