### PR TITLE
tooling: Auto-init submodules in make firmware if missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ $(MPY_DIR):
 
 .PHONY: firmware
 firmware: $(MPY_DIR) ## Build MicroPython firmware with current drivers
-	set -e
+	@set -e
 	@if [ ! -f "$(MPY_DIR)/lib/micropython-lib/README.md" ]; then \
 		echo "Initializing submodules for $(BOARD)..."; \
 		cd $(CURDIR)/$(MPY_DIR)/ports/stm32 && $(MAKE) BOARD=$(BOARD) submodules; \
@@ -112,7 +112,7 @@ firmware: $(MPY_DIR) ## Build MicroPython firmware with current drivers
 
 .PHONY: firmware-update
 firmware-update: $(MPY_DIR) ## Update the MicroPython clone and board-specific submodules
-	set -e
+	@set -e
 	@echo "Updating micropython-steami..."
 	rm -rf $(CURDIR)/$(MPY_DIR)/lib/micropython-steami-lib
 	cd $(CURDIR)/$(MPY_DIR) && git fetch origin && git checkout $(MICROPYTHON_BRANCH) && git checkout -- lib/micropython-steami-lib && git pull --ff-only

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,10 @@ $(MPY_DIR):
 
 .PHONY: firmware
 firmware: $(MPY_DIR) ## Build MicroPython firmware with current drivers
+	@if [ ! -f "$(MPY_DIR)/lib/micropython-lib/README.md" ]; then \
+		echo "Initializing submodules for $(BOARD)..."; \
+		cd $(CURDIR)/$(MPY_DIR)/ports/stm32 && $(MAKE) BOARD=$(BOARD) submodules; \
+	fi
 	@echo "Linking local drivers..."
 	rm -rf $(CURDIR)/$(MPY_DIR)/lib/micropython-steami-lib
 	ln -s $(CURDIR) $(CURDIR)/$(MPY_DIR)/lib/micropython-steami-lib

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ $(MPY_DIR):
 
 .PHONY: firmware
 firmware: $(MPY_DIR) ## Build MicroPython firmware with current drivers
+	set -e
 	@if [ ! -f "$(MPY_DIR)/lib/micropython-lib/README.md" ]; then \
 		echo "Initializing submodules for $(BOARD)..."; \
 		cd $(CURDIR)/$(MPY_DIR)/ports/stm32 && $(MAKE) BOARD=$(BOARD) submodules; \
@@ -111,6 +112,7 @@ firmware: $(MPY_DIR) ## Build MicroPython firmware with current drivers
 
 .PHONY: firmware-update
 firmware-update: $(MPY_DIR) ## Update the MicroPython clone and board-specific submodules
+	set -e
 	@echo "Updating micropython-steami..."
 	rm -rf $(CURDIR)/$(MPY_DIR)/lib/micropython-steami-lib
 	cd $(CURDIR)/$(MPY_DIR) && git fetch origin && git checkout $(MICROPYTHON_BRANCH) && git checkout -- lib/micropython-steami-lib && git pull --ff-only


### PR DESCRIPTION
Closes #360

## Summary

`make firmware` now auto-detects when the `micropython-lib` submodule is missing and runs `make submodules` (the official MicroPython command) to initialize all required submodules for the board.

This is a no-op when submodules are already initialized. It auto-recovers after branch switches, fresh clones, or any operation that resets submodule state.

## What changed

Added a check at the start of the `firmware` target:

```makefile
@if [ ! -f "$(MPY_DIR)/lib/micropython-lib/README.md" ]; then \
    echo "Initializing submodules for $(BOARD)..."; \
    cd $(CURDIR)/$(MPY_DIR)/ports/stm32 && $(MAKE) BOARD=$(BOARD) submodules; \
fi
```

Uses MicroPython's own `make submodules` which initializes all board-specific submodules, not just `micropython-lib`.

## Test plan

- [x] `make -n firmware` shows correct command sequence
- [x] `make firmware` succeeds when submodules are already present (no-op)
- [x] `make firmware` auto-recovers after submodule loss