### PR TITLE
tooling: Replace cd && make with make -C in firmware targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,21 +94,21 @@ $(MPY_DIR):
 	@echo "Cloning micropython-steami into $(CURDIR)/$(MPY_DIR)..."
 	@mkdir -p $(dir $(CURDIR)/$(MPY_DIR))
 	git clone --branch $(MICROPYTHON_BRANCH) $(MICROPYTHON_REPO) $(CURDIR)/$(MPY_DIR)
-	cd $(CURDIR)/$(MPY_DIR)/ports/stm32 && $(MAKE) BOARD=$(BOARD) submodules
+	$(MAKE) -C $(STM32_DIR) BOARD=$(BOARD) submodules
 
 .PHONY: firmware
 firmware: $(MPY_DIR) ## Build MicroPython firmware with current drivers
 	@set -e
 	@if [ ! -f "$(MPY_DIR)/lib/micropython-lib/README.md" ]; then \
 		echo "Initializing submodules for $(BOARD)..."; \
-		cd $(CURDIR)/$(MPY_DIR)/ports/stm32 && $(MAKE) BOARD=$(BOARD) submodules; \
+		$(MAKE) -C $(STM32_DIR) BOARD=$(BOARD) submodules; \
 	fi
 	@echo "Linking local drivers..."
 	rm -rf $(CURDIR)/$(MPY_DIR)/lib/micropython-steami-lib
 	ln -s $(CURDIR) $(CURDIR)/$(MPY_DIR)/lib/micropython-steami-lib
 	@echo "Building firmware for $(BOARD)..."
-	cd $(CURDIR)/$(MPY_DIR)/ports/stm32 && $(MAKE) BOARD=$(BOARD)
-	@echo "Firmware ready: $(CURDIR)/$(MPY_DIR)/ports/stm32/build-$(BOARD)/firmware.hex"
+	$(MAKE) -C $(STM32_DIR) BOARD=$(BOARD)
+	@echo "Firmware ready: $(STM32_DIR)/build-$(BOARD)/firmware.hex"
 
 .PHONY: firmware-update
 firmware-update: $(MPY_DIR) ## Update the MicroPython clone and board-specific submodules
@@ -117,11 +117,11 @@ firmware-update: $(MPY_DIR) ## Update the MicroPython clone and board-specific s
 	rm -rf $(CURDIR)/$(MPY_DIR)/lib/micropython-steami-lib
 	cd $(CURDIR)/$(MPY_DIR) && git fetch origin && git checkout $(MICROPYTHON_BRANCH) && git checkout -- lib/micropython-steami-lib && git pull --ff-only
 	@echo "Updating required submodules for $(BOARD)..."
-	cd $(CURDIR)/$(MPY_DIR)/ports/stm32 && $(MAKE) BOARD=$(BOARD) submodules
+	$(MAKE) -C $(STM32_DIR) BOARD=$(BOARD) submodules
 
 .PHONY: deploy
 deploy: $(MPY_DIR) ## Flash firmware to the board via OpenOCD
-	cd $(CURDIR)/$(MPY_DIR)/ports/stm32 && $(MAKE) BOARD=$(BOARD) deploy-openocd
+	$(MAKE) -C $(STM32_DIR) BOARD=$(BOARD) deploy-openocd
 
 .PHONY: run
 run: ## Run a script on the board with live output (SCRIPT=path/to/file.py)
@@ -145,8 +145,8 @@ run-main: ## Re-execute main.py on the board and capture output
 
 .PHONY: firmware-clean
 firmware-clean: ## Clean firmware build artifacts
-	@if [ -d "$(MPY_DIR)/ports/stm32" ]; then \
-		cd $(MPY_DIR)/ports/stm32 && $(MAKE) BOARD=$(BOARD) clean; \
+	@if [ -d "$(STM32_DIR)" ]; then \
+		$(MAKE) -C $(STM32_DIR) BOARD=$(BOARD) clean; \
 	fi
 
 # --- Hardware ---

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,10 @@ firmware-update: $(MPY_DIR) ## Update the MicroPython clone and board-specific s
 	@set -e
 	@echo "Updating micropython-steami..."
 	rm -rf $(CURDIR)/$(MPY_DIR)/lib/micropython-steami-lib
-	cd $(CURDIR)/$(MPY_DIR) && git fetch origin && git checkout $(MICROPYTHON_BRANCH) && git checkout -- lib/micropython-steami-lib && git pull --ff-only
+	git -C $(CURDIR)/$(MPY_DIR) fetch origin
+	git -C $(CURDIR)/$(MPY_DIR) checkout $(MICROPYTHON_BRANCH)
+	git -C $(CURDIR)/$(MPY_DIR) checkout -- lib/micropython-steami-lib
+	git -C $(CURDIR)/$(MPY_DIR) pull --ff-only
 	@echo "Updating required submodules for $(BOARD)..."
 	$(MAKE) -C $(STM32_DIR) BOARD=$(BOARD) submodules
 

--- a/env.mk
+++ b/env.mk
@@ -7,4 +7,4 @@ MICROPYTHON_BRANCH ?= stm32-steami-rev1d-final
 BOARD ?= STEAM32_WB55RG
 BUILD_DIR ?= .build
 MPY_DIR ?= $(BUILD_DIR)/micropython-steami
-STM32_DIR = $(MPY_DIR)/ports/stm32
+STM32_DIR ?= $(MPY_DIR)/ports/stm32

--- a/env.mk
+++ b/env.mk
@@ -7,3 +7,4 @@ MICROPYTHON_BRANCH ?= stm32-steami-rev1d-final
 BOARD ?= STEAM32_WB55RG
 BUILD_DIR ?= .build
 MPY_DIR ?= $(BUILD_DIR)/micropython-steami
+STM32_DIR = $(MPY_DIR)/ports/stm32


### PR DESCRIPTION
Closes #363

## Summary

Replaces all `cd ... && $(MAKE) ...` patterns with `$(MAKE) -C ...` in firmware-related targets. With `.ONESHELL`, `cd` changes the working directory for the rest of the recipe, which can cause surprising behavior. `$(MAKE) -C` changes directory only for the sub-make invocation.

## Changes

- **`env.mk`**: added `STM32_DIR` variable to factorize `$(MPY_DIR)/ports/stm32`
- **`Makefile`**: replaced 6 occurrences across 5 targets:
  - `$(MPY_DIR)` (clone + submodules)
  - `firmware` (submodule init + build)
  - `firmware-update` (submodules)
  - `deploy` (flash)
  - `firmware-clean` (clean)

The only remaining `cd` is in `firmware-update` for git commands — that's legitimate (git, not make).

## Test plan

- [x] `make -n firmware` shows `make -C` instead of `cd && make`
- [x] `make -n deploy` correct
- [x] `make -n firmware-clean` correct
- [x] No `cd.*$(MAKE)` remaining in Makefile