### PR TITLE
ci: Validate PR title with commitlint and enforce trailing period.

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -35,4 +35,6 @@ jobs:
         run: npx --no-install commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
       - name: "📜 Validate PR title (used as squash commit message)"
-        run: echo "${{ github.event.pull_request.title }}" | npx --no-install commitlint --verbose
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s\n' "$PR_TITLE" | npx --no-install commitlint --verbose

--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: "📜 Validate commit messages"
         run: npx --no-install commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+
+      - name: "📜 Validate PR title (used as squash commit message)"
+        run: echo "${{ github.event.pull_request.title }}" | npx --no-install commitlint --verbose

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   rules: {
     'subject-case': [0],
-    'subject-full-stop': [0],
+    'subject-full-stop': [2, 'always', '.'],
     'header-max-length': [2, 'always', 78],
     'scope-enum': [
       2,


### PR DESCRIPTION
Closes #365

## Summary

Since we use squash merge, the PR title becomes the commit message in main. This PR adds validation of the PR title using the same commitlint rules as commits.

### Changes

1. **`check-commits.yml`**: added a step that pipes the PR title through commitlint
2. **`commitlint.config.js`**: re-enabled `subject-full-stop` rule (`[2, 'always', '.']`)

### What gets caught now

| PR title | Error |
|---|---|
| `Feat/migrate screen library` | type-empty, subject-empty, subject-full-stop |
| `feat(steami_screen): add widget library` | subject-full-stop |
| `feat(steami_config): display all config fields  in show_config.py` | subject-full-stop |
| `feat(bme280): Add altitude computation.` | Passes |

### Impact

- PR titles must now end with a period — matches the documented convention in CONTRIBUTING.md
- Commit messages must also end with a period (same rule applies via the existing hook)
- Existing PRs with bad titles will fail CI on next push/edit

## Test plan

- [x] commitlint correctly rejects titles without period
- [x] commitlint correctly rejects non-conventional titles
- [x] commitlint passes valid titles