### PR TITLE
fix: Force frozen rebuild and switch deploy to pyOCD.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
         "dockerfile": "Dockerfile"
     },
 
-    // USB access for STeaMi board (DAPLink / mpremote / OpenOCD).
+    // USB access for STeaMi board (DAPLink / mpremote / pyOCD / OpenOCD).
     // Privileged mode is required for firmware flashing and board communication.
     // This is incompatible with GitHub Codespaces but essential for local use.
     "privileged": true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ Then run `make setup` to install all dependencies and git hooks. This creates a 
 
 ## Dev Container
 
-A dev container is available for VS Code (local Docker only, not GitHub Codespaces). It includes all prerequisites out of the box: Python 3.10, Node.js 22, ruff, pytest, mpremote, arm-none-eabi-gcc, OpenOCD, and the GitHub CLI.
+A dev container is available for VS Code (local Docker only, not GitHub Codespaces). It includes all prerequisites out of the box: Python 3.10, Node.js 22, ruff, pytest, mpremote, pyOCD, arm-none-eabi-gcc, OpenOCD, and the GitHub CLI.
 
 1. Open the repository in VS Code
 2. When prompted, click **Reopen in Container** (or use the command palette: *Dev Containers: Reopen in Container*)
@@ -140,7 +140,7 @@ The container also provides:
 * **zsh + oh-my-zsh** as default shell with persistent shell history
 * **Pylance** configured with MicroPython STM32 stubs (no false `import machine` errors)
 * **Serial Monitor** extension for board communication
-* **USB passthrough** for mpremote, OpenOCD, and firmware flashing (the container runs in privileged mode with `/dev/bus/usb` mounted)
+* **USB passthrough** for mpremote, pyOCD, OpenOCD, and firmware flashing (the container runs in privileged mode with `/dev/bus/usb` mounted)
 * **udev rules** for the DAPLink interface (auto-started on container creation)
 
 Note: GitHub Codespaces is not supported because the container requires privileged mode and USB device access for board communication.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,8 @@ For local development (without dev container):
 * Python 3.10+
 * Node.js 22+ (for husky, commitlint, lint-staged, semantic-release)
 * `arm-none-eabi-gcc` toolchain (for `make firmware`)
-* OpenOCD (for `make deploy`)
+* `pyocd` (for `make deploy`, installed via `pip install -e ".[flash]"`)
+* OpenOCD (optional, for `make deploy-openocd`)
 * `mpremote` (installed via `pip install -e ".[test]"`)
 * GitHub CLI (`gh`)
 
@@ -192,7 +193,8 @@ The drivers are "frozen" into the MicroPython firmware for the STeaMi board. The
 ```bash
 make firmware       # Clone micropython-steami (if needed), link local drivers, build
 make firmware-update # Refresh the MicroPython clone and board-specific submodules
-make deploy         # Flash firmware via OpenOCD
+make deploy         # Flash firmware via pyOCD (default)
+make deploy-openocd # Flash firmware via OpenOCD (alternative)
 make run SCRIPT=lib/steami_config/examples/show_config.py      # Run with live output
 make deploy-script SCRIPT=lib/.../calibrate_magnetometer.py    # Deploy as main.py for autonomous use
 make run-main       # Re-execute the deployed main.py

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(VENV_DIR)/bin/activate:
 
 .PHONY: install
 install: $(VENV_DIR)/bin/activate node_modules/.package-lock.json ## Install dev tools (pip + npm)
-	$(VENV_DIR)/bin/pip install -e ".[dev,test]"
+	$(VENV_DIR)/bin/pip install -e ".[dev,test,flash]"
 
 # --- Linting ---
 
@@ -128,7 +128,7 @@ deploy: deploy-pyocd ## Flash firmware (default: pyocd)
 
 .PHONY: deploy-pyocd
 deploy-pyocd: $(MPY_DIR) ## Flash firmware via pyOCD (CMSIS-DAP)
-	pyocd flash $(STM32_DIR)/build-$(BOARD)/firmware.elf --format elf
+	$(PYTHON) -m pyocd flash $(STM32_DIR)/build-$(BOARD)/firmware.elf --format elf
 
 .PHONY: deploy-openocd
 deploy-openocd: $(MPY_DIR) ## Flash firmware via OpenOCD

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ firmware: $(MPY_DIR) ## Build MicroPython firmware with current drivers
 	rm -rf $(CURDIR)/$(MPY_DIR)/lib/micropython-steami-lib
 	ln -s $(CURDIR) $(CURDIR)/$(MPY_DIR)/lib/micropython-steami-lib
 	@echo "Building firmware for $(BOARD)..."
+	rm -f $(STM32_DIR)/build-$(BOARD)/frozen_content.c
 	$(MAKE) -C $(STM32_DIR) BOARD=$(BOARD)
 	@echo "Firmware ready: $(STM32_DIR)/build-$(BOARD)/firmware.hex"
 
@@ -123,7 +124,14 @@ firmware-update: $(MPY_DIR) ## Update the MicroPython clone and board-specific s
 	$(MAKE) -C $(STM32_DIR) BOARD=$(BOARD) submodules
 
 .PHONY: deploy
-deploy: $(MPY_DIR) ## Flash firmware to the board via OpenOCD
+deploy: deploy-pyocd ## Flash firmware (default: pyocd)
+
+.PHONY: deploy-pyocd
+deploy-pyocd: $(MPY_DIR) ## Flash firmware via pyOCD (CMSIS-DAP)
+	pyocd flash $(STM32_DIR)/build-$(BOARD)/firmware.elf --format elf
+
+.PHONY: deploy-openocd
+deploy-openocd: $(MPY_DIR) ## Flash firmware via OpenOCD
 	$(MAKE) -C $(STM32_DIR) BOARD=$(BOARD) deploy-openocd
 
 .PHONY: run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.7"
 [project.optional-dependencies]
 dev = ["ruff==0.11.6", "micropython-stm32-stubs>=1.24"]
 test = ["pytest==7.4.0", "pyyaml==6.0.2", "mpremote>=1.0"]
+flash = ["pyocd>=0.44"]
 
 [tool.setuptools]
 # No Python packages to install — this project contains MicroPython drivers


### PR DESCRIPTION
Closes #348

## Summary

Two changes to fix the firmware build and deploy workflow:

### 1. Force frozen module regeneration

Delete `frozen_content.c` before each build to force MicroPython to regenerate it. This ensures that driver modifications are always included in the firmware, even when timestamps are stale due to the symlink.

### 2. Switch default deploy to pyOCD

Replace OpenOCD with pyOCD as the default flash tool. pyOCD reliably detects the STeaMi board via CMSIS-DAP and flashes correctly, while OpenOCD has issues (#380).

New targets:
- `make deploy` — alias for `deploy-pyocd` (default)
- `make deploy-pyocd` — flash via pyOCD
- `make deploy-openocd` — flash via OpenOCD (kept for compatibility)

### 3. Install pyOCD via pip

Added `flash` optional dependency group in pyproject.toml with `pyocd>=0.44`. `make install` now installs `.[dev,test,flash]`.

## Verified

- `make firmware && make deploy` — builds and flashes correctly via pyOCD
- Board runs updated firmware after deploy
- pyOCD auto-detects the STeaMi board (no target pack needed)