### PR TITLE
fix: Bump lodash and lodash-es to 4.18 for dependabot alerts.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4366,16 +4366,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   },
   "overrides": {
     "picomatch": "^4.0.4",
-    "lodash": "^4.17.22",
+    "lodash": "^4.18.0",
+    "lodash-es": "^4.18.0",
     "tmp": "^0.2.4",
     "brace-expansion": "^2.0.3"
   }


### PR DESCRIPTION
## Summary

Resolves all 5 open Dependabot alerts on `package-lock.json`:

| # | Severity | Package | Vuln | Fix |
|---|---|---|---|---|
| 14 | High | lodash-es | Code injection via `_.template` | 4.18.0 |
| 15 | Medium | lodash-es | Prototype pollution via `_.unset/_.omit` | 4.18.0 |
| 16 | Medium | lodash | Prototype pollution via `_.unset/_.omit` | 4.18.0 |
| 17 | High | lodash | Code injection via `_.template` | 4.18.0 |
| 4 | Medium | picomatch | Method injection in POSIX classes | 4.0.4 |

## Changes

Updated npm overrides in `package.json`:

```json
"overrides": {
  "picomatch": "^4.0.4",
  "lodash": "^4.18.0",      // was ^4.17.22
  "lodash-es": "^4.18.0",   // new
  "tmp": "^0.2.4",
  "brace-expansion": "^2.0.3"
}
```

The previous override `^4.17.22` was not strict enough to force the patched 4.18.0 release. Adding an explicit `lodash-es` override (it was previously implicit via `lodash`).

`picomatch ^4.0.4` was already in place — Dependabot will close that alert automatically.

Regenerated `package-lock.json` via `npm install`.

## Test plan

- [x] `npm install` succeeds with new overrides
- [x] `make test` — 349 mock tests pass
- [x] `npm audit` — only 2 transitive vulns remain (in `node_modules/npm/node_modules/`, bundled in `npm` 11.12.1 itself, not actionable from this project)

## Note

Two additional vulns are reported by `npm audit` inside `node_modules/npm/node_modules/` (brace-expansion and picomatch). These are bundled inside the `npm` package itself (a transitive dep of `@semantic-release/npm`). They cannot be fixed from this project — `npm` 11.12.1 is the latest version. They are not flagged by Dependabot since they live in a nested `node_modules`.