### PR TITLE
tooling: Force LF line endings via .gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Force LF line endings on every text file.
+#
+# This repo is developed on Linux / macOS / WSL. Shell scripts (including
+# husky git hooks) and MicroPython sources must stay LF — a CRLF shebang
+# breaks `#!/usr/bin/env sh` on Unix shells, and CRLF in Python files
+# confuses some MicroPython parsers.
+#
+# `text=auto eol=lf` lets Git detect text vs. binary files automatically
+# and checks text files out as LF, regardless of the contributor's
+# `core.autocrlf` setting (which is `true` by default on Git for Windows).
+
+* text=auto eol=lf
+
+# Explicit declarations for common binary artifacts — no EOL conversion.
+*.bin binary
+*.hex binary
+*.elf binary
+*.dfu binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.ico binary
+*.gif binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.bz2 binary


### PR DESCRIPTION
## Summary
Add a repository-level `.gitattributes` pinning every text file to LF. Husky hooks, MicroPython sources, and Makefile recipes all assume LF, and Git for Windows' default `core.autocrlf=true` was silently rewriting `.husky/pre-commit` to CRLF on Windows + WSL clones — the trailing `\r` breaks `#!/usr/bin/env sh` on WSL.

## Approach
```
* text=auto eol=lf

*.bin binary
*.hex binary
# ... other binary extensions
```

`text=auto` lets Git auto-detect text vs. binary. `eol=lf` forces text files to LF on checkout on every platform. Explicit `binary` entries protect firmware artifacts from any conversion.

## Migration for existing clones
After pull, contributors (especially on Windows + WSL) should run:

```bash
git pull
git add --renormalize .
git status  # if anything appears, commit it
```

Verified on the current tree: nothing shows up, all tracked files were already LF locally. Windows + WSL clones, however, likely have CRLF versions on disk — the renormalize step fixes them without any content change.

## Test plan
- [x] `git add --renormalize .` on a clean LF tree is a no-op
- [ ] Aline re-clones / renormalizes on Windows + WSL → husky hooks run without the shebang error

## Closes
#396