### PR TITLE
fix(steami_screen): Improve text scaling using pixel-by-pixel framebuf.

### DIFF
--- a/lib/steami_screen/README.md
+++ b/lib/steami_screen/README.md
@@ -74,8 +74,7 @@ screen.text("Big", at="CENTER", scale=2)
 
 Cardinal positions: `"N"`, `"NE"`, `"E"`, `"SE"`, `"S"`, `"SW"`, `"W"`, `"NW"`, `"CENTER"`.
 
-Note: `scale=2` produces a true pixel-scale zoom on SSD1327 displays via pixel-by-pixel
-framebuf rendering. Other backends can implement `draw_scaled_text()` for native scaling support.
+Note: `scale` > 1 produces a true pixel-scale zoom on SSD1327 displays via pixel-by-pixel framebuf rendering. Other backends can implement `draw_scaled_text()` for native scaling support. Backends without it fall back to a bold offset effect.
 
 ---
 

--- a/lib/steami_screen/README.md
+++ b/lib/steami_screen/README.md
@@ -74,7 +74,8 @@ screen.text("Big", at="CENTER", scale=2)
 
 Cardinal positions: `"N"`, `"NE"`, `"E"`, `"SE"`, `"S"`, `"SW"`, `"W"`, `"NW"`, `"CENTER"`.
 
-Note: `scale=2` produces a bold effect (text drawn with 1px offset), not a true pixel-scale zoom. Backends can provide `draw_scaled_text()` for true scaling.
+Note: `scale=2` produces a true pixel-scale zoom on SSD1327 displays via pixel-by-pixel
+framebuf rendering. Other backends can implement `draw_scaled_text()` for native scaling support.
 
 ---
 

--- a/lib/steami_screen/steami_screen/ssd1327.py
+++ b/lib/steami_screen/steami_screen/ssd1327.py
@@ -10,8 +10,6 @@ Usage on the STeaMi board:
     display = SSD1327Display(raw)
 """
 
-import framebuf
-
 from steami_screen.colors import rgb_to_gray4
 
 
@@ -22,6 +20,11 @@ class SSD1327Display:
         self._raw = raw
         self.width = getattr(raw, "width", 128)
         self.height = getattr(raw, "height", 128)
+        # Resolve fill_rect dispatch once at init (avoids repeated hasattr)
+        if hasattr(raw, "fill_rect"):
+            self._fill_rect_raw = raw.fill_rect
+        else:
+            self._fill_rect_raw = raw.framebuf.fill_rect
 
     def fill(self, color):
         self._raw.fill(rgb_to_gray4(color))
@@ -36,11 +39,7 @@ class SSD1327Display:
         self._raw.line(x1, y1, x2, y2, rgb_to_gray4(color))
 
     def fill_rect(self, x, y, w, h, color):
-        gray = rgb_to_gray4(color)
-        if hasattr(self._raw, "fill_rect"):
-            self._raw.fill_rect(x, y, w, h, gray)
-        else:
-            self._raw.framebuf.fill_rect(x, y, w, h, gray)
+        self._fill_rect_raw(x, y, w, h, rgb_to_gray4(color))
 
     def rect(self, x, y, w, h, color):
         gray = rgb_to_gray4(color)
@@ -53,14 +52,17 @@ class SSD1327Display:
         self._raw.show()
 
     def draw_scaled_text(self, text, x, y, color, scale):
-        """Draw text scaled up using pixel-by-pixel framebuf rendering.
+        """Draw text with true pixel-scale zoom.
 
-        Renders each character into a temporary 8x8 MONO_HLSB framebuf,
-        reads each lit pixel, and draws a scale x scale filled rectangle.
-        This produces a true pixel-scale zoom instead of a bold offset effect.
+        Each character is rendered into a temporary 8x8 MONO_HLSB framebuf,
+        then each lit pixel is expanded into a scale x scale filled rectangle
+        on the display. The framebuf import is deferred to avoid breaking
+        imports in CPython environments where framebuf is not available.
         """
+        import framebuf
 
         gray = rgb_to_gray4(color)
+        blit = self._fill_rect_raw
 
         char_buf = bytearray(8)
         fb = framebuf.FrameBuffer(char_buf, 8, 8, framebuf.MONO_HLSB)
@@ -72,20 +74,5 @@ class SSD1327Display:
             for py in range(8):
                 for px in range(8):
                     if fb.pixel(px, py):
-                        if hasattr(self._raw, "fill_rect"):
-                            self._raw.fill_rect(
-                                cx + px * scale,
-                                y + py * scale,
-                                scale,
-                                scale,
-                                gray,
-                            )
-                        else:
-                            self._raw.framebuf.fill_rect(
-                                cx + px * scale,
-                                y + py * scale,
-                                scale,
-                                scale,
-                                gray,
-                            )
+                        blit(cx + px * scale, y + py * scale, scale, scale, gray)
             cx += 8 * scale

--- a/lib/steami_screen/steami_screen/ssd1327.py
+++ b/lib/steami_screen/steami_screen/ssd1327.py
@@ -10,6 +10,8 @@ Usage on the STeaMi board:
     display = SSD1327Display(raw)
 """
 
+import framebuf
+
 from steami_screen.colors import rgb_to_gray4
 
 
@@ -18,8 +20,8 @@ class SSD1327Display:
 
     def __init__(self, raw):
         self._raw = raw
-        self.width = getattr(raw, 'width', 128)
-        self.height = getattr(raw, 'height', 128)
+        self.width = getattr(raw, "width", 128)
+        self.height = getattr(raw, "height", 128)
 
     def fill(self, color):
         self._raw.fill(rgb_to_gray4(color))
@@ -35,17 +37,55 @@ class SSD1327Display:
 
     def fill_rect(self, x, y, w, h, color):
         gray = rgb_to_gray4(color)
-        if hasattr(self._raw, 'fill_rect'):
+        if hasattr(self._raw, "fill_rect"):
             self._raw.fill_rect(x, y, w, h, gray)
         else:
             self._raw.framebuf.fill_rect(x, y, w, h, gray)
 
     def rect(self, x, y, w, h, color):
         gray = rgb_to_gray4(color)
-        if hasattr(self._raw, 'rect'):
+        if hasattr(self._raw, "rect"):
             self._raw.rect(x, y, w, h, gray)
         else:
             self._raw.framebuf.rect(x, y, w, h, gray)
 
     def show(self):
         self._raw.show()
+
+    def draw_scaled_text(self, text, x, y, color, scale):
+        """Draw text scaled up using pixel-by-pixel framebuf rendering.
+
+        Renders each character into a temporary 8x8 MONO_HLSB framebuf,
+        reads each lit pixel, and draws a scale x scale filled rectangle.
+        This produces a true pixel-scale zoom instead of a bold offset effect.
+        """
+
+        gray = rgb_to_gray4(color)
+
+        char_buf = bytearray(8)
+        fb = framebuf.FrameBuffer(char_buf, 8, 8, framebuf.MONO_HLSB)
+
+        cx = x
+        for char in text:
+            fb.fill(0)
+            fb.text(char, 0, 0, 1)
+            for py in range(8):
+                for px in range(8):
+                    if fb.pixel(px, py):
+                        if hasattr(self._raw, "fill_rect"):
+                            self._raw.fill_rect(
+                                cx + px * scale,
+                                y + py * scale,
+                                scale,
+                                scale,
+                                gray,
+                            )
+                        else:
+                            self._raw.framebuf.fill_rect(
+                                cx + px * scale,
+                                y + py * scale,
+                                scale,
+                                scale,
+                                gray,
+                            )
+            cx += 8 * scale


### PR DESCRIPTION
## Summary
Improve `_draw_scaled_text()` to produce a true pixel-scale zoom instead of a bold offset effect. Closes #369

## Changes
- Implemented **approach 3 (backend-specific)**: added `draw_scaled_text()` directly in `SSD1327Display` (`steami_screen/ssd1327.py`)
- The method renders each character into a temporary 8x8 `MONO_HLSB` framebuf, reads each lit pixel with `framebuf.pixel()`, and draws a `scale x scale` filled rectangle for each lit pixel
- `_draw_scaled_text()` in `device.py` already checks `hasattr(self._d, 'draw_scaled_text')` and delegates to the backend — no changes needed in `device.py`
- This approach allows each backend (SSD1327, GC9A01, etc.) to implement its own optimized scaling strategy

## Checklist
- [x] `ruff check` passes
- [x] `python -m pytest tests/ -k mock -v` passes (no mock test broken)
- [x] Tested on hardware (STM32WB55 / STeaMi board)
- [x] README updated (if adding/changing public API) — N/A, internal method only
- [x] Examples added/updated — N/A, existing examples benefit automatically
- [x] Commit messages follow `<scope>: <Description.>` format