### PR TITLE
tooling: Enable ruff preview rules E203, E302, and E303.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,29 +1,4 @@
 {
     "python.languageServer": "Pylance",
-    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-    "python.analysis.typeCheckingMode": "basic",
-    "python.analysis.extraPaths": [
-        "lib/apds9960",
-        "lib/bme280",
-        "lib/bq27441",
-        "lib/daplink_bridge",
-        "lib/daplink_flash",
-        "lib/gc9a01",
-        "lib/hts221",
-        "lib/im34dt05",
-        "lib/ism330dl",
-        "lib/lis2mdl",
-        "lib/mcp23009e",
-        "lib/ssd1327",
-        "lib/steami_config",
-        "lib/steami_screen",
-        "lib/vl53l1x",
-        "lib/wsen-hids",
-        "lib/wsen-pads"
-    ],
-    "python.analysis.stubPath": "typings",
-    "python.analysis.diagnosticSeverityOverrides": {
-        "reportMissingModuleSource": "none",
-        "reportWildcardImportFromLibrary": "none"
-    }
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
         "lib/mcp23009e",
         "lib/ssd1327",
         "lib/steami_config",
+        "lib/steami_screen",
         "lib/vl53l1x",
         "lib/wsen-hids",
         "lib/wsen-pads"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,9 +24,6 @@
     "python.analysis.stubPath": "typings",
     "python.analysis.diagnosticSeverityOverrides": {
         "reportMissingModuleSource": "none",
-        "reportWildcardImportFromLibrary": "none",
-        "reportGeneralTypeIssues": "warning"
-    },
-    "pylint.enabled": false,
-    "mypy-type-checker.enabled": false
+        "reportWildcardImportFromLibrary": "none"
+    }
 }

--- a/lib/apds9960/examples/light_theremin.py
+++ b/lib/apds9960/examples/light_theremin.py
@@ -66,7 +66,6 @@ try:
             # Map the light range to an index in our note array (0 to 14)
             note_index = (clamped_light - MIN_LIGHT) * (TOTAL_NOTES - 1) // range_light
 
-
             # Fetch the perfect harmonic frequency
             freq = PENTATONIC_NOTES[note_index]
 
@@ -76,7 +75,6 @@ try:
                 buzzer_ch.pulse_width_percent(50)
                 print("Light: {} | Note: {} | Freq: {} Hz".format(light_level, note_index, freq), end="\r")
                 last_freq = freq
-
 
         sleep_ms(20)
 

--- a/lib/mcp23009e/examples/i2c_scan.py
+++ b/lib/mcp23009e/examples/i2c_scan.py
@@ -13,7 +13,6 @@ sleep(1)
 reset.value(1)
 
 
-
 print("=" * 60)
 print("Scanner I2C - Recherche des périphériques")
 print("=" * 60)

--- a/lib/steami_config/steami_config/device.py
+++ b/lib/steami_config/steami_config/device.py
@@ -12,6 +12,7 @@ _SENSOR_KEYS = {
 # Reverse map: short key -> sensor name.
 _KEY_SENSORS = {v: k for k, v in _SENSOR_KEYS.items()}
 
+
 class SteamiConfig(object):
     """Persistent configuration stored in the DAPLink F103 config zone.
 
@@ -238,7 +239,6 @@ class SteamiConfig(object):
             "oy": cal.get("oy", 0.0),
             "oz": cal.get("oz", 0.0),
         }
-
 
     def apply_accelerometer_calibration(self, ism330dl_instance):
         """Apply stored accelerometer calibration to an ISM330DL instance."""

--- a/lib/steami_screen/steami_screen/device.py
+++ b/lib/steami_screen/steami_screen/device.py
@@ -40,6 +40,7 @@ FACES = {
 
 # --- Cardinal position names ---
 
+
 class Screen:
     """High-level wrapper around a raw display backend."""
 
@@ -195,7 +196,6 @@ class Screen:
         # Fill
         if fill_w > 0:
             self._fill_rect(bx, by, fill_w, bar_h, color)
-
 
     def gauge(self, val, min_val=0, max_val=100, color=LIGHT):
         """Draw a circular arc gauge (270 deg, gap at bottom).

--- a/lib/wsen-pads/examples/altitude.py
+++ b/lib/wsen-pads/examples/altitude.py
@@ -10,6 +10,7 @@ i2c = I2C(1)
 
 sensor = WSEN_PADS(i2c)
 
+
 def pressure_to_altitude(p):
     return 44330 * (1 - (p / SEA_LEVEL_PRESSURE) ** EXPONENT)
 

--- a/lib/wsen-pads/examples/pressure_trend.py
+++ b/lib/wsen-pads/examples/pressure_trend.py
@@ -15,6 +15,7 @@ pressure_history = []
 MAX_VALUES = 10
 THRESHOLD = 0.5  # sensitivity (hPa)
 
+
 def get_trend(values):
     if len(values) < 2:
         return "N/A"

--- a/lib/wsen-pads/examples/temp_pressure_display.py
+++ b/lib/wsen-pads/examples/temp_pressure_display.py
@@ -15,6 +15,7 @@ PRESS_MAX = 1060.0
 i2c = I2C(1)
 sensor = WSEN_PADS(i2c)
 
+
 def bar_graph(value, vmin, vmax, width=20):
     # Clamp value
     if value < vmin:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,3 +128,28 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[tool.pyright]
+typeCheckingMode = "basic"
+stubPath = "typings"
+extraPaths = [
+    "lib/apds9960",
+    "lib/bme280",
+    "lib/bq27441",
+    "lib/daplink_bridge",
+    "lib/daplink_flash",
+    "lib/gc9a01",
+    "lib/hts221",
+    "lib/im34dt05",
+    "lib/ism330dl",
+    "lib/lis2mdl",
+    "lib/mcp23009e",
+    "lib/ssd1327",
+    "lib/steami_config",
+    "lib/steami_screen",
+    "lib/vl53l1x",
+    "lib/wsen-hids",
+    "lib/wsen-pads",
+]
+reportMissingModuleSource = "none"
+reportWildcardImportFromLibrary = "none"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,13 @@ select = [
   "C90",    # McCabe cyclomatic complexity
   "DTZ",    # flake8-datetimez
   "E",      # pycodestyle
+  "E203",   # (preview) whitespace before ':', ';', or ','
   "E225",   # (preview) missing whitespace around operator
   "E261",   # (preview) at least two spaces before inline comment
   "E262",   # (preview) inline comment must start with '# '
   "E265",   # (preview) block comment must start with '# '
+  "E302",   # (preview) expected 2 blank lines before function/class definition
+  "E303",   # (preview) too many blank lines
   "EXE",    # flake8-executable
   "F",      # Pyflakes
   "G",      # flake8-logging-format

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,6 @@ def pytest_addoption(parser):
     )
 
 
-
 def pytest_collection_modifyitems(config, items):
     port = config.getoption("--port")
     driver = config.getoption("--driver")


### PR DESCRIPTION
## Summary
Enable three pycodestyle preview rules that were silently inactive due to `explicit-preview-rules = true`:

| Rule | Description | Where it was missed |
|---|---|---|
| E203 | Whitespace before `:` (catches `else :`, `if x :`) | PR #399 (Aline's tamagotchi) |
| E302 | Expected 2 blank lines before function/class | PR #376 (Kaan's spirit level) |
| E303 | Too many blank lines | PR #376 |

Auto-fixed the 11 pre-existing violations across 8 files (all trivial blank-line additions/removals).

## Test plan
- [x] `make lint` passes with the new rules active
- [x] `make test-mock` passes (364 passed, 2 skipped)
- [x] `echo "else :" | ruff check` now triggers E203
- [x] Single blank line before a top-level `def` now triggers E302

## Closes
#400