### PR TITLE
tooling: Enable ruff preview rules E231, E275, E301, E305, and W391.

### DIFF
--- a/lib/wsen-hids/examples/comfort_monitor.py
+++ b/lib/wsen-hids/examples/comfort_monitor.py
@@ -18,6 +18,7 @@ def comfort_label(humidity):
     else:
         return "Humid"
 
+
 while True:
     humidity, temperature = sensor.read_one_shot()
     comfort = comfort_label(humidity)

--- a/lib/wsen-hids/examples/dew_point.py
+++ b/lib/wsen-hids/examples/dew_point.py
@@ -20,6 +20,7 @@ def dew_point_celsius(temperature_c, humidity):
     dp = (b * gamma) / (a - gamma)
     return dp
 
+
 humidity, temperature = sensor.read_one_shot()
 dew_point = dew_point_celsius(temperature, humidity)
 

--- a/lib/wsen-pads/examples/altitude.py
+++ b/lib/wsen-pads/examples/altitude.py
@@ -14,6 +14,7 @@ sensor = WSEN_PADS(i2c)
 def pressure_to_altitude(p):
     return 44330 * (1 - (p / SEA_LEVEL_PRESSURE) ** EXPONENT)
 
+
 for _ in range(10):
     pressure, temp = sensor.read()
 

--- a/lib/wsen-pads/examples/pressure_trend.py
+++ b/lib/wsen-pads/examples/pressure_trend.py
@@ -33,6 +33,7 @@ def get_trend(values):
     else:
         return "falling"
 
+
 while True:
     pressure = sensor.pressure_hpa()
 

--- a/lib/wsen-pads/examples/temp_pressure_display.py
+++ b/lib/wsen-pads/examples/temp_pressure_display.py
@@ -28,6 +28,7 @@ def bar_graph(value, vmin, vmax, width=20):
 
     return "[" + "#" * filled + "-" * (width - filled) + "]"
 
+
 while True:
     pressure, temp = sensor.read()
     temp_bar = bar_graph(temp, TEMP_MIN, TEMP_MAX)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,15 @@ select = [
   "E",      # pycodestyle
   "E203",   # (preview) whitespace before ':', ';', or ','
   "E225",   # (preview) missing whitespace around operator
+  "E231",   # (preview) missing whitespace after ','
   "E261",   # (preview) at least two spaces before inline comment
   "E262",   # (preview) inline comment must start with '# '
   "E265",   # (preview) block comment must start with '# '
+  "E275",   # (preview) missing whitespace after keyword
+  "E301",   # (preview) blank line between methods
   "E302",   # (preview) expected 2 blank lines before function/class definition
   "E303",   # (preview) too many blank lines
+  "E305",   # (preview) expected 2 blank lines after function/class definition
   "EXE",    # flake8-executable
   "F",      # Pyflakes
   "G",      # flake8-logging-format
@@ -78,6 +82,7 @@ select = [
   "T20",    # flake8-print: no print() in production code
   "TCH",    # flake8-type-checking
   "W",      # pycodestyle
+  "W391",   # (preview) too many newlines at end of file
   "YTT",    # flake8-2020
 ]
 ignore = [


### PR DESCRIPTION
## Summary
Second round of explicit preview rules, following #400 (E203/E302/E303).

| Rule | Description | Violations fixed |
|---|---|---|
| E231 | Missing whitespace after `,` | 0 (prevention) |
| E275 | Missing whitespace after keyword | 0 (prevention) |
| E301 | Blank line between methods | 0 (prevention) |
| E305 | 2 blank lines after function/class definition | 5 (auto-fixed) |
| W391 | Too many newlines at end of file | 0 (prevention) |

The 5 E305 violations were in example files (`wsen-hids`, `wsen-pads`) where a function definition was followed by module-level code with only 1 blank line.

## Test plan
- [x] `make lint` passes
- [x] `make test-mock` passes (364 passed, 2 skipped)

## Closes
#402